### PR TITLE
Accessibility 82→100, SEO 92→100 (Lighthouse)

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -789,6 +789,17 @@
 			text-decoration:none;
 		}
 
+		/* In-text links carry an underline so they don't rely on color alone
+		   (WCAG 1.4.1). Header/nav/CTA links keep their own styling. */
+		#main p a, #main li a, #main td a, #aboutmewidth a {
+			text-decoration: underline;
+			text-underline-offset: 2px;
+		}
+		/* On the dark footer the standard link blue falls below 4.5:1. */
+		#aboutmewidth a {
+			color:#5ab6e0;
+		}
+
 		a:hover,a:visited:hover
 		{
 			color:#0a5675;
@@ -1042,7 +1053,7 @@
 			color:#14202b;
 			margin:1px 0 4px;
 		}
-		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#7a8a96; }
+		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#566270; }
 		.pie-col > div[id^="pie_"] { display:inline-block; }
 
 		.recommended {
@@ -1500,7 +1511,7 @@
 		</div>
         
 		<div id="content">
-			<div id="main">
+			<div id="main" role="main">
                 <div id="broughttoyou">
                     Von <a href="https://keto-calculator.ankerl.com/de/">keto-calculator.ankerl.com</a> &middot; <a href="../" hreflang="en">English</a>
                 </div>
@@ -1529,17 +1540,17 @@
 					<p>Für deine persönlichen Empfehlungen gib bitte ein paar Daten zu dir ein.</p>
 					
 					<table class="userinputs">
-						<tr><td><input name="sex" tabindex="1" type="radio" value="1">Weiblich <input name="sex" tabindex="2" type="radio" value="0">Männlich</td></tr>
+						<tr><td><label><input name="sex" type="radio" value="1">Weiblich</label> <label><input name="sex" type="radio" value="0">Männlich</label></td></tr>
 
-						<tr><td><input name="kg" tabindex="3" type="number" step="0.1" value="" placeholder="80"> kg Gewicht (<input name="lbs" type="number" step="0.1" value=""> lbs)
+						<tr><td><input name="kg" type="number" step="0.1" value="" placeholder="80" aria-label="Gewicht in Kilogramm"> kg Gewicht (<input name="lbs" type="number" step="0.1" value="" aria-label="Gewicht in Pfund"> lbs)
 						<div id="weight_warning"></div>
 						</td></tr>
 
-						<tr><td><input name="height" tabindex="4" type="number" value="" placeholder="180"> cm groß (<input name="feet" type="number" value="" step="1" style="width:3.4em">' <input name="inch" type="number" step="1" value="" style="width:3.8em">")
+						<tr><td><input name="height" type="number" value="" placeholder="180" aria-label="Größe in Zentimetern"> cm groß (<input name="feet" type="number" value="" step="1" style="width:3.4em" aria-label="Größe: Fuß">' <input name="inch" type="number" step="1" value="" style="width:3.8em" aria-label="Größe: Zoll">")
 						<div id="height_warning"></div>
 						</td></tr>
 
-							<tr><td>Geburtsdatum: <input id="bday" name="bday" tabindex="6" type="date">
+							<tr><td><label for="bday">Geburtsdatum:</label> <input id="bday" name="bday" type="date">
 							<div id="date_warning"></div>				
 						</td></tr>
 
@@ -1554,7 +1565,7 @@
 					<p>Mit diesen Daten lässt sich dein <a href="https://en.wikipedia.org/wiki/Basal_metabolic_rate" onclick="return gatrack(this);">Grundumsatz (BMR)</a> berechnen. Diese Seite verwendet die <a href="https://www.freedieting.com/calorie_needs.html" onclick="return gatrack(this);">Mifflin-St.-Jeor-Formel</a>, die in <a href="https://www.ncbi.nlm.nih.gov/pubmed/15883556" onclick="return gatrack(this);">zwei</a>&nbsp;<a href="https://www.ncbi.nlm.nih.gov/pubmed/18688113" onclick="return gatrack(this);">Studien</a> am genauesten war.</p>
 
 					<ul>
-						<li><input disabled="disabled" name="bmr" type="number" value=""> kcal Grundumsatz</li>
+						<li><input disabled="disabled" name="bmr" type="number" value="" aria-label="Grundumsatz in kcal"> kcal Grundumsatz</li>
 					</ul>
 					
 					<p>Der Grundumsatz entspricht in etwa dem Ruheumsatz. Dein tatsächlicher Tagesverbrauch hängt davon ab, wie aktiv du im Schnitt bist. Aus diesem Aktivitätsgrad berechnen wir deinen gesamten täglichen Energieverbrauch (TDEE). Das ist die Menge an Kalorien, die du täglich essen musst, wenn du dein Gewicht halten willst.</p>
@@ -1562,17 +1573,17 @@
 					<ul>
 						<li>
 							<table>
-								<tr><td><input name="level" type="radio" value="0"></td><td>Sitzend. Typischer Bürojob, kaum bis kein Sport.</td></tr>
-								<tr><td><input name="level" type="radio" value="1"></td><td>Leicht aktiv. Viel auf den Beinen, z. B. im Einzelhandel. 1–3 Stunden leichter Sport pro Woche.</td></tr>
-								<tr><td><input name="level" type="radio" value="2"></td><td>Mäßig aktiv. 3–5 Stunden pro Woche, z. B. täglich 15 Minuten Rad fahren und 3-mal pro Woche Krafttraining.</td></tr>
-								<tr><td><input name="level" type="radio" value="3"></td><td>Sehr aktiv. Körperliche Arbeit, hartes Training an 6–7 Tagen pro Woche.</td></tr>
-								<tr><td><input name="level" type="radio" value="4"></td><td>Eigener Wert: <input disabled="disabled" name="custom_expenditure" type="number" value=""> kcal</td></tr>
+								<tr><td><input name="level" type="radio" value="0" aria-label="Aktivitätslevel: überwiegend sitzend"></td><td>Sitzend. Typischer Bürojob, kaum bis kein Sport.</td></tr>
+								<tr><td><input name="level" type="radio" value="1" aria-label="Aktivitätslevel: leicht aktiv"></td><td>Leicht aktiv. Viel auf den Beinen, z. B. im Einzelhandel. 1–3 Stunden leichter Sport pro Woche.</td></tr>
+								<tr><td><input name="level" type="radio" value="2" aria-label="Aktivitätslevel: mäßig aktiv"></td><td>Mäßig aktiv. 3–5 Stunden pro Woche, z. B. täglich 15 Minuten Rad fahren und 3-mal pro Woche Krafttraining.</td></tr>
+								<tr><td><input name="level" type="radio" value="3" aria-label="Aktivitätslevel: sehr aktiv"></td><td>Sehr aktiv. Körperliche Arbeit, hartes Training an 6–7 Tagen pro Woche.</td></tr>
+								<tr><td><input name="level" type="radio" value="4" aria-label="Aktivitätslevel: eigener Verbrauch"></td><td>Eigener Wert: <input disabled="disabled" name="custom_expenditure" type="number" value="" aria-label="Eigener täglicher Energieverbrauch in kcal"> kcal</td></tr>
 							</table>
 						</li>
 					</ul>
 
 					<ul>
-						<li><input disabled="disabled" name="energy" type="number" value=""> kcal täglicher Energieverbrauch</li>
+						<li><input disabled="disabled" name="energy" type="number" value="" aria-label="Täglicher Energieverbrauch in kcal"> kcal täglicher Energieverbrauch</li>
 					</ul>
 
 
@@ -1582,7 +1593,7 @@
 					<p>Finden wir deinen Körperfettanteil heraus. Basierend auf Größe und Gewicht liegt er vermutlich <a href="https://www.ncbi.nlm.nih.gov/pubmed/16469982" onclick="return gatrack(this);">bei etwa <span class="estimated_bodyfat_percent"></span>%</a>. Am genauesten misst ein <a href="https://en.wikipedia.org/wiki/Dual_energy_X-ray_absorptiometry" onclick="return gatrack(this);">DEXA-Scan</a>. Auch die Messung der Hautfalten mit <a href="https://www.amazon.com/gp/product/B0000AN3UB/ref=as_li_ss_tl?ie=UTF8&amp;camp=1789&amp;creative=390957&amp;creativeASIN=B0000AN3UB&amp;linkCode=as2&amp;tag=martanke-20" onclick="return gatrack(this);">einem guten Caliper</a> ist recht genau. Am einfachsten schätzt du ihn anhand von <a href="https://martin.ankerl.com/2016/01/04/body-fat-comparison-pictures/" onclick="return gatrack(this);">Vergleichsbildern</a>. Mehr: <a href="https://www.builtlean.com/2012/09/24/body-fat-percentage-men-women/" onclick="return gatrack(this);">1</a>, <a href="https://www.leighpeele.com/body-fat-pictures-and-percentages" onclick="return gatrack(this);">2</a>, <a href="https://www.nerdfitness.com/blog/2012/07/02/body-fat-percentage/" onclick="return gatrack(this);">3</a>. Du kannst auch <a href="https://www.healthcentral.com/cholesterol/home-body-fat-test-2774-143.html" onclick="return gatrack(this);">diesen Rechner</a> ausprobieren, der kann aber ungenau sein.</p>
 
 					<ul>
-						<li><input name="bodyfat" type="number" value="" placeholder="20"> % Körperfett</li>
+						<li><input name="bodyfat" type="number" value="" placeholder="20" aria-label="Körperfettanteil in Prozent"> % Körperfett</li>
 					</ul>
 
 					<p>Bei <span class="bodyfat_percentage"></span>% Körperfett hast du <span class="lean_kg"></span>kg (<span class="lean_lbs"></span>lbs) fettfreie Masse und <span class="fat_kg"></span>kg (<span class="fat_lbs"></span>lbs) Körperfett. Davon sind etwa <span class="essential_fat_kg"></span>kg (<span class="essential_fat_lbs"></span>lbs) <a href="https://en.wikipedia.org/wiki/Body_fat_percentage#Typical_body_fat_amounts" onclick="return gatrack(this);">essentielles Körperfett</a>, das du nicht verlieren darfst.</p>
@@ -1616,7 +1627,7 @@
 
 
 					<ul>
-						<li><input name="carbs" type="number" value="25"> g Netto-Kohlenhydrate pro Tag (änderbar)</li>
+						<li><input name="carbs" type="number" value="25" aria-label="Tägliche Netto-Kohlenhydrate in Gramm"> g Netto-Kohlenhydrate pro Tag (änderbar)</li>
 					</ul>
 					
 
@@ -1649,13 +1660,13 @@
 								</tr>
 
 								<tr>
-									<td><input disabled="disabled" name="protein_min" type="number" value="">
+									<td><input disabled="disabled" name="protein_min" type="number" value="" aria-label="Minimales Eiweiß in Gramm">
 									g&nbsp;Minimum</td>
 
-									<td><input name="protein_chosen" type="number" value="">
+									<td><input name="protein_chosen" type="number" value="" aria-label="Gewähltes Eiweiß in Gramm">
 									g&nbsp;gewählt</td>
 
-									<td><input disabled="disabled" name="protein_max" type="number" value="">
+									<td><input disabled="disabled" name="protein_max" type="number" value="" aria-label="Maximales Eiweiß in Gramm">
 									g&nbsp;Maximum</td>
 								</tr>
 
@@ -1710,35 +1721,35 @@
 								</tr>
 								
 								<tr>
-									<td><input disabled="disabled" name="min_deficit_percent_form" type="number" value="">
+									<td><input disabled="disabled" name="min_deficit_percent_form" type="number" value="" aria-label="Minimales Kaloriendefizit in Prozent">
 									%&nbsp;Defizit</td>
 
-									<td><input name="target_deficit_form" type="number" value="">
+									<td><input name="target_deficit_form" type="number" value="" aria-label="Gewähltes Kaloriendefizit in Prozent">
 									%&nbsp;Defizit</td>
 
-									<td><input disabled="disabled" type="number" value="0">
+									<td><input disabled="disabled" type="number" value="0" aria-label="Kaloriendefizit bei Erhaltung in Prozent">
 									%&nbsp;Defizit</td>
 								</tr>										
 								
 								<tr>
-									<td width="33%"><input disabled="disabled" name="kcal_min_form" type="number" value="">
+									<td width="33%"><input disabled="disabled" name="kcal_min_form" type="number" value="" aria-label="Minimale tägliche Kalorien in kcal">
 									kcal&nbsp;min</td>
 
-									<td width="33%"><input name="target_kcal_form" type="number" value="">
+									<td width="33%"><input name="target_kcal_form" type="number" value="" aria-label="Gewählte tägliche Kalorien in kcal">
 									kcal&nbsp;gewählt</td>
 
-									<td><input disabled="disabled" name="kcal_max_form" type="number" value="">
+									<td><input disabled="disabled" name="kcal_max_form" type="number" value="" aria-label="Tägliche Kalorien bei Erhaltung in kcal">
 									kcal&nbsp;max</td>
 								</tr>
 								
 								<tr>
-									<td><input disabled="disabled" name="fat_min_form" type="number" value="">
+									<td><input disabled="disabled" name="fat_min_form" type="number" value="" aria-label="Minimales Fett in Gramm">
 									g&nbsp;Fett&nbsp;min</td>
 
-									<td><input name="target_fat_form" type="number" value="">
+									<td><input name="target_fat_form" type="number" value="" aria-label="Gewähltes Fett in Gramm">
 									g&nbsp;Fett&nbsp;gewählt</td>
 
-									<td><input disabled="disabled" name="fat_max_form" type="number" value="">
+									<td><input disabled="disabled" name="fat_max_form" type="number" value="" aria-label="Maximales Fett in Gramm">
 									g&nbsp;Fett&nbsp;max</td>
 								</tr>										
 								
@@ -1863,9 +1874,9 @@
                         
 						<p>
 						<ul>
-						<li>Beginn am <input id="graphstartdate" name="graphstartdate" type="date">.</li>
+						<li><label for="graphstartdate">Beginn am</label> <input id="graphstartdate" name="graphstartdate" type="date">.</li>
 					
-						<li>Anzeigen in <input name="chart_weight_type" type="radio" value="0">kg oder <input name="chart_weight_type" type="radio" value="1">lbs</li>
+						<li>Anzeigen in <label><input name="chart_weight_type" type="radio" value="0">kg</label> oder <label><input name="chart_weight_type" type="radio" value="1">lbs</label></li>
 						</ul></p>
 
 						<div id="chart">
@@ -1874,7 +1885,7 @@
 							</div>
 						</div>
                         
-						<p>Für alle Daten-Fans: Du kannst <a id="csvdownload" download="KetoCalculatorForecast.csv" href="javascript:void(0)">eine CSV-Datei deines prognostizierten Gewichtsverlaufs herunterladen</a>. Sie enthält alle Daten der obigen Grafik.
+						<p>Für alle Daten-Fans: Du kannst <a id="csvdownload" download="KetoCalculatorForecast.csv">eine CSV-Datei deines prognostizierten Gewichtsverlaufs herunterladen</a>. Sie enthält alle Daten der obigen Grafik.
                     </div>
 
 					<!-- Keto Top (7271241487) — second in-content unit. Placed on the
@@ -2057,7 +2068,7 @@
                                 
                         <p>
                             <center>
-                                <textarea class="copytext" cols="2" name="reddit_copypaste" readonly="readonly" rows="13"></textarea>
+                                <textarea class="copytext" cols="2" name="reddit_copypaste" readonly="readonly" rows="13" aria-label="Text für den Reddit-Beitrag"></textarea>
                             </center>
                         </p>
                         

--- a/de/index.html
+++ b/de/index.html
@@ -797,7 +797,7 @@
 		}
 		/* On the dark footer the standard link blue falls below 4.5:1. */
 		#aboutmewidth a {
-			color:#5ab6e0;
+			color:#7fc7e6;
 		}
 
 		a:hover,a:visited:hover
@@ -982,7 +982,7 @@
 			color:#14202b;
 			min-width:62px;
 		}
-		.macro-val i { font-size:14px; font-style:normal; font-weight:500; color:#7a8a96; margin-left:1px; }
+		.macro-val i { font-size:14px; font-style:normal; font-weight:500; color:#5a6b78; margin-left:1px; }
 		.macro-name {
 			font-family:'Space Grotesk','Helvetica Neue',Arial,sans-serif;
 			font-weight:600;
@@ -993,7 +993,7 @@
 		.macro-meta {
 			font-family:'Space Grotesk','Helvetica Neue',Arial,sans-serif;
 			font-size:12.5px;
-			color:#6b7a86;
+			color:#5a6b78;
 			white-space:nowrap;
 		}
 
@@ -1019,7 +1019,7 @@
 			font-family:'PT Serif',Georgia,'Times New Roman',serif;
 			font-size:13px;
 			font-style:italic;
-			color:#6b7a86;
+			color:#5a6b78;
 			margin:14px 0 0;
 			padding-top:13px;
 			border-top:1px solid #dce8f0;
@@ -1053,7 +1053,7 @@
 			color:#14202b;
 			margin:1px 0 4px;
 		}
-		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#566270; }
+		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#5a6b78; }
 		.pie-col > div[id^="pie_"] { display:inline-block; }
 
 		.recommended {
@@ -1492,8 +1492,7 @@
 	<style>
 	a:focus-visible,
 	button:focus-visible,
-	summary:focus-visible,
-	[tabindex]:focus-visible {
+	summary:focus-visible {
 		outline: 3px solid rgba(18,148,200,0.65);
 		outline-offset: 2px;
 		border-radius: 4px;
@@ -1511,7 +1510,7 @@
 		</div>
         
 		<div id="content">
-			<div id="main" role="main">
+			<main id="main">
                 <div id="broughttoyou">
                     Von <a href="https://keto-calculator.ankerl.com/de/">keto-calculator.ankerl.com</a> &middot; <a href="../" hreflang="en">English</a>
                 </div>
@@ -1565,25 +1564,25 @@
 					<p>Mit diesen Daten lässt sich dein <a href="https://en.wikipedia.org/wiki/Basal_metabolic_rate" onclick="return gatrack(this);">Grundumsatz (BMR)</a> berechnen. Diese Seite verwendet die <a href="https://www.freedieting.com/calorie_needs.html" onclick="return gatrack(this);">Mifflin-St.-Jeor-Formel</a>, die in <a href="https://www.ncbi.nlm.nih.gov/pubmed/15883556" onclick="return gatrack(this);">zwei</a>&nbsp;<a href="https://www.ncbi.nlm.nih.gov/pubmed/18688113" onclick="return gatrack(this);">Studien</a> am genauesten war.</p>
 
 					<ul>
-						<li><input disabled="disabled" name="bmr" type="number" value="" aria-label="Grundumsatz in kcal"> kcal Grundumsatz</li>
+						<li><label><input disabled="disabled" name="bmr" type="number" value=""> kcal Grundumsatz</label></li>
 					</ul>
 					
 					<p>Der Grundumsatz entspricht in etwa dem Ruheumsatz. Dein tatsächlicher Tagesverbrauch hängt davon ab, wie aktiv du im Schnitt bist. Aus diesem Aktivitätsgrad berechnen wir deinen gesamten täglichen Energieverbrauch (TDEE). Das ist die Menge an Kalorien, die du täglich essen musst, wenn du dein Gewicht halten willst.</p>
 					
 					<ul>
 						<li>
-							<table>
-								<tr><td><input name="level" type="radio" value="0" aria-label="Aktivitätslevel: überwiegend sitzend"></td><td>Sitzend. Typischer Bürojob, kaum bis kein Sport.</td></tr>
-								<tr><td><input name="level" type="radio" value="1" aria-label="Aktivitätslevel: leicht aktiv"></td><td>Leicht aktiv. Viel auf den Beinen, z. B. im Einzelhandel. 1–3 Stunden leichter Sport pro Woche.</td></tr>
-								<tr><td><input name="level" type="radio" value="2" aria-label="Aktivitätslevel: mäßig aktiv"></td><td>Mäßig aktiv. 3–5 Stunden pro Woche, z. B. täglich 15 Minuten Rad fahren und 3-mal pro Woche Krafttraining.</td></tr>
-								<tr><td><input name="level" type="radio" value="3" aria-label="Aktivitätslevel: sehr aktiv"></td><td>Sehr aktiv. Körperliche Arbeit, hartes Training an 6–7 Tagen pro Woche.</td></tr>
+							<table role="radiogroup" aria-label="Aktivitätslevel">
+								<tr><td><input id="level0" name="level" type="radio" value="0"></td><td><label for="level0">Sitzend. Typischer Bürojob, kaum bis kein Sport.</label></td></tr>
+								<tr><td><input id="level1" name="level" type="radio" value="1"></td><td><label for="level1">Leicht aktiv. Viel auf den Beinen, z. B. im Einzelhandel. 1–3 Stunden leichter Sport pro Woche.</label></td></tr>
+								<tr><td><input id="level2" name="level" type="radio" value="2"></td><td><label for="level2">Mäßig aktiv. 3–5 Stunden pro Woche, z. B. täglich 15 Minuten Rad fahren und 3-mal pro Woche Krafttraining.</label></td></tr>
+								<tr><td><input id="level3" name="level" type="radio" value="3"></td><td><label for="level3">Sehr aktiv. Körperliche Arbeit, hartes Training an 6–7 Tagen pro Woche.</label></td></tr>
 								<tr><td><input name="level" type="radio" value="4" aria-label="Aktivitätslevel: eigener Verbrauch"></td><td>Eigener Wert: <input disabled="disabled" name="custom_expenditure" type="number" value="" aria-label="Eigener täglicher Energieverbrauch in kcal"> kcal</td></tr>
 							</table>
 						</li>
 					</ul>
 
 					<ul>
-						<li><input disabled="disabled" name="energy" type="number" value="" aria-label="Täglicher Energieverbrauch in kcal"> kcal täglicher Energieverbrauch</li>
+						<li><label><input disabled="disabled" name="energy" type="number" value=""> kcal täglicher Energieverbrauch</label></li>
 					</ul>
 
 
@@ -1593,7 +1592,7 @@
 					<p>Finden wir deinen Körperfettanteil heraus. Basierend auf Größe und Gewicht liegt er vermutlich <a href="https://www.ncbi.nlm.nih.gov/pubmed/16469982" onclick="return gatrack(this);">bei etwa <span class="estimated_bodyfat_percent"></span>%</a>. Am genauesten misst ein <a href="https://en.wikipedia.org/wiki/Dual_energy_X-ray_absorptiometry" onclick="return gatrack(this);">DEXA-Scan</a>. Auch die Messung der Hautfalten mit <a href="https://www.amazon.com/gp/product/B0000AN3UB/ref=as_li_ss_tl?ie=UTF8&amp;camp=1789&amp;creative=390957&amp;creativeASIN=B0000AN3UB&amp;linkCode=as2&amp;tag=martanke-20" onclick="return gatrack(this);">einem guten Caliper</a> ist recht genau. Am einfachsten schätzt du ihn anhand von <a href="https://martin.ankerl.com/2016/01/04/body-fat-comparison-pictures/" onclick="return gatrack(this);">Vergleichsbildern</a>. Mehr: <a href="https://www.builtlean.com/2012/09/24/body-fat-percentage-men-women/" onclick="return gatrack(this);">1</a>, <a href="https://www.leighpeele.com/body-fat-pictures-and-percentages" onclick="return gatrack(this);">2</a>, <a href="https://www.nerdfitness.com/blog/2012/07/02/body-fat-percentage/" onclick="return gatrack(this);">3</a>. Du kannst auch <a href="https://www.healthcentral.com/cholesterol/home-body-fat-test-2774-143.html" onclick="return gatrack(this);">diesen Rechner</a> ausprobieren, der kann aber ungenau sein.</p>
 
 					<ul>
-						<li><input name="bodyfat" type="number" value="" placeholder="20" aria-label="Körperfettanteil in Prozent"> % Körperfett</li>
+						<li><label><input name="bodyfat" type="number" value="" placeholder="20"> % Körperfett</label></li>
 					</ul>
 
 					<p>Bei <span class="bodyfat_percentage"></span>% Körperfett hast du <span class="lean_kg"></span>kg (<span class="lean_lbs"></span>lbs) fettfreie Masse und <span class="fat_kg"></span>kg (<span class="fat_lbs"></span>lbs) Körperfett. Davon sind etwa <span class="essential_fat_kg"></span>kg (<span class="essential_fat_lbs"></span>lbs) <a href="https://en.wikipedia.org/wiki/Body_fat_percentage#Typical_body_fat_amounts" onclick="return gatrack(this);">essentielles Körperfett</a>, das du nicht verlieren darfst.</p>
@@ -1627,7 +1626,7 @@
 
 
 					<ul>
-						<li><input name="carbs" type="number" value="25" aria-label="Tägliche Netto-Kohlenhydrate in Gramm"> g Netto-Kohlenhydrate pro Tag (änderbar)</li>
+						<li><label><input name="carbs" type="number" value="25"> g Netto-Kohlenhydrate pro Tag (änderbar)</label></li>
 					</ul>
 					
 
@@ -2094,7 +2093,7 @@
                         </p>
 					</div>
 				</form>
-			</div>
+			</main>
 
 			
 			
@@ -2139,7 +2138,7 @@
 				<div id="aboutme">
 					<div id="aboutmewidth">
 						<i class="sprite sprite-me" style="float:left; margin-right: 1em; margin-top:4px;" title="Martin Leitner-Ankerl"></i> Erstellt von <b>Martin Leitner-Ankerl</b>. Ich bin Softwareentwickler und beschäftige mich seit Jahren mit der ketogenen Ernährung. Ich habe diesen Rechner gebaut und <a href="https://www.reddit.com/r/keto/comments/127sm0/keto_calculator/" onclick="return gatrack(this);">im Oktober 2012 auf /r/keto vorgestellt</a>, weil die Keto-Ratschläge im Netz vage waren und ich für mich selbst genaue Zahlen wollte. Die Berechnung basiert auf der wissenschaftlich geprüften Mifflin-St.-Jeor-Formel und den Eiweiß- und Fett-Empfehlungen aus Phinney und Voleks <i>The Art and Science of Low Carbohydrate Living</i> — dem Buch, aus dem ich am meisten gelernt habe. Ich bin kein Arzt und kein Ernährungsberater; das hier ist einfach das Werkzeug, das ich mir selbst gewünscht habe — frei geteilt. Du findest mich auf <a href="https://www.reddit.com/user/martinus/" onclick="return gatrack(this);">Reddit</a> und in <a href="https://martin.ankerl.com/" onclick="return gatrack(this);">meinem Blog</a>. Bitte lies den <a href="disclaimer.html" onclick="return gatrack(this);">Haftungsausschluss und die Cookie-Zustimmung</a>.
-						<p style="font-size:smaller; color:#6b7a86; margin-top:0.6em;">Erstellt im Oktober 2012 · zuletzt überprüft im Juni 2026. Die Formeln sind seit der Veröffentlichung unverändert und werden regelmäßig auf Richtigkeit überprüft.</p>
+						<p style="font-size:smaller; color:#98a6b3; margin-top:0.6em;">Erstellt im Oktober 2012 · zuletzt überprüft im Juni 2026. Die Formeln sind seit der Veröffentlichung unverändert und werden regelmäßig auf Richtigkeit überprüft.</p>
 						
 						<span style="clear:left; display:block;"></span>
 					</div>

--- a/dev/build_de.py
+++ b/dev/build_de.py
@@ -126,19 +126,19 @@ rep('<h2>Your Fat Loss Calculation</h2>', '<h2>Deine Fettabbau-Berechnung</h2>')
 rep('<p>To get your personal customized recommendations, please enter some data about yourself.</p>',
     '<p>Für deine persönlichen Empfehlungen gib bitte ein paar Daten zu dir ein.</p>')
 
-rep('<input name="sex" tabindex="1" type="radio" value="1">Female <input name="sex" tabindex="2" type="radio" value="0">Male',
-    '<input name="sex" tabindex="1" type="radio" value="1">Weiblich <input name="sex" tabindex="2" type="radio" value="0">Männlich')
+rep('<label><input name="sex" type="radio" value="1">Female</label> <label><input name="sex" type="radio" value="0">Male</label>',
+    '<label><input name="sex" type="radio" value="1">Weiblich</label> <label><input name="sex" type="radio" value="0">Männlich</label>')
 
 # Weight row: metric-first
-rep('<input name="lbs" tabindex="3" type="number" step="0.1" value="" placeholder="180"> lbs weight (<input name="kg" type="number" step="0.1" value=""> kg)',
-    '<input name="kg" tabindex="3" type="number" step="0.1" value="" placeholder="80"> kg Gewicht (<input name="lbs" type="number" step="0.1" value=""> lbs)')
+rep('<input name="lbs" type="number" step="0.1" value="" placeholder="180" aria-label="Weight in pounds"> lbs weight (<input name="kg" type="number" step="0.1" value="" aria-label="Weight in kilograms"> kg)',
+    '<input name="kg" type="number" step="0.1" value="" placeholder="80" aria-label="Gewicht in Kilogramm"> kg Gewicht (<input name="lbs" type="number" step="0.1" value="" aria-label="Gewicht in Pfund"> lbs)')
 
 # Height row: metric-first
-rep('<input name="feet" tabindex="4" type="number" value="" step="1" style="width:3.4em" placeholder="5">\' <input name="inch" tabindex="5" type="number" step="1" value="" style="width:3.8em" placeholder="9">" tall (<input name="height" type="number" value=""> cm)',
-    '<input name="height" tabindex="4" type="number" value="" placeholder="180"> cm groß (<input name="feet" type="number" value="" step="1" style="width:3.4em">\' <input name="inch" type="number" step="1" value="" style="width:3.8em">")')
+rep('<input name="feet" type="number" value="" step="1" style="width:3.4em" placeholder="5" aria-label="Height: feet">\' <input name="inch" type="number" step="1" value="" style="width:3.8em" placeholder="9" aria-label="Height: inches">" tall (<input name="height" type="number" value="" aria-label="Height in centimeters"> cm)',
+    '<input name="height" type="number" value="" placeholder="180" aria-label="Größe in Zentimetern"> cm groß (<input name="feet" type="number" value="" step="1" style="width:3.4em" aria-label="Größe: Fuß">\' <input name="inch" type="number" step="1" value="" style="width:3.8em" aria-label="Größe: Zoll">")')
 
-rep('<tr><td>Date of birth: <input id="bday" name="bday" tabindex="6" type="date">',
-    '<tr><td>Geburtsdatum: <input id="bday" name="bday" tabindex="6" type="date">')
+rep('<tr><td><label for="bday">Date of birth:</label> <input id="bday" name="bday" type="date">',
+    '<tr><td><label for="bday">Geburtsdatum:</label> <input id="bday" name="bday" type="date">')
 
 # Energy expenditure
 rep('<h3>Determine Your Energy Expenditure</h3>', '<h3>Bestimme deinen Energieverbrauch</h3>')
@@ -151,16 +151,16 @@ rep('kcal Base Metabolic Rate</li>', 'kcal Grundumsatz</li>')
 rep("<p>The BMR resembles the resting metabolic rate. The real daily energy expenditure depends on how active you are on average. Based on that activity level we calculate your actual total daily energy expenditure (TDEE). This is the number of calories you need to consume each day when you do not want to lose weight.</p>",
     '<p>Der Grundumsatz entspricht in etwa dem Ruheumsatz. Dein tatsächlicher Tagesverbrauch hängt davon ab, wie aktiv du im Schnitt bist. Aus diesem Aktivitätsgrad berechnen wir deinen gesamten täglichen Energieverbrauch (TDEE). Das ist die Menge an Kalorien, die du täglich essen musst, wenn du dein Gewicht halten willst.</p>')
 
-rep('<tr><td><input name="level" type="radio" value="0"></td><td>Sedentary. Typical desk job, little to no exercise.</td></tr>',
-    '<tr><td><input name="level" type="radio" value="0"></td><td>Sitzend. Typischer Bürojob, kaum bis kein Sport.</td></tr>')
-rep('<tr><td><input name="level" type="radio" value="1"></td><td>Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</td></tr>',
-    '<tr><td><input name="level" type="radio" value="1"></td><td>Leicht aktiv. Viel auf den Beinen, z. B. im Einzelhandel. 1–3 Stunden leichter Sport pro Woche.</td></tr>')
-rep('<tr><td><input name="level" type="radio" value="2"></td><td>Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</td></tr>',
-    '<tr><td><input name="level" type="radio" value="2"></td><td>Mäßig aktiv. 3–5 Stunden pro Woche, z. B. täglich 15 Minuten Rad fahren und 3-mal pro Woche Krafttraining.</td></tr>')
-rep('<tr><td><input name="level" type="radio" value="3"></td><td>Very active. Construction workers, hard exercise 6–7 days per week</td></tr>',
-    '<tr><td><input name="level" type="radio" value="3"></td><td>Sehr aktiv. Körperliche Arbeit, hartes Training an 6–7 Tagen pro Woche.</td></tr>')
-rep('<tr><td><input name="level" type="radio" value="4"></td><td>Custom: <input disabled="disabled" name="custom_expenditure" type="number" value=""> kcal</td></tr>',
-    '<tr><td><input name="level" type="radio" value="4"></td><td>Eigener Wert: <input disabled="disabled" name="custom_expenditure" type="number" value=""> kcal</td></tr>')
+rep('<tr><td><input name="level" type="radio" value="0" aria-label="Activity level: sedentary"></td><td>Sedentary. Typical desk job, little to no exercise.</td></tr>',
+    '<tr><td><input name="level" type="radio" value="0" aria-label="Aktivitätslevel: überwiegend sitzend"></td><td>Sitzend. Typischer Bürojob, kaum bis kein Sport.</td></tr>')
+rep('<tr><td><input name="level" type="radio" value="1" aria-label="Activity level: lightly active"></td><td>Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</td></tr>',
+    '<tr><td><input name="level" type="radio" value="1" aria-label="Aktivitätslevel: leicht aktiv"></td><td>Leicht aktiv. Viel auf den Beinen, z. B. im Einzelhandel. 1–3 Stunden leichter Sport pro Woche.</td></tr>')
+rep('<tr><td><input name="level" type="radio" value="2" aria-label="Activity level: moderately active"></td><td>Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</td></tr>',
+    '<tr><td><input name="level" type="radio" value="2" aria-label="Aktivitätslevel: mäßig aktiv"></td><td>Mäßig aktiv. 3–5 Stunden pro Woche, z. B. täglich 15 Minuten Rad fahren und 3-mal pro Woche Krafttraining.</td></tr>')
+rep('<tr><td><input name="level" type="radio" value="3" aria-label="Activity level: very active"></td><td>Very active. Construction workers, hard exercise 6–7 days per week</td></tr>',
+    '<tr><td><input name="level" type="radio" value="3" aria-label="Aktivitätslevel: sehr aktiv"></td><td>Sehr aktiv. Körperliche Arbeit, hartes Training an 6–7 Tagen pro Woche.</td></tr>')
+rep('<tr><td><input name="level" type="radio" value="4" aria-label="Activity level: custom"></td><td>Custom: <input disabled="disabled" name="custom_expenditure" type="number" value="" aria-label="Custom daily energy expenditure in kcal"> kcal</td></tr>',
+    '<tr><td><input name="level" type="radio" value="4" aria-label="Aktivitätslevel: eigener Verbrauch"></td><td>Eigener Wert: <input disabled="disabled" name="custom_expenditure" type="number" value="" aria-label="Eigener täglicher Energieverbrauch in kcal"> kcal</td></tr>')
 
 rep('kcal daily energy expenditure</li>', 'kcal täglicher Energieverbrauch</li>')
 
@@ -170,8 +170,8 @@ rep('<h3>How Much Body Fat do you Have?</h3>', '<h3>Wie hoch ist dein Körperfet
 rep('<p>Let\'s find out your body fat percentage. Based on your height and weight, your body fat percentage might be <a href="https://www.ncbi.nlm.nih.gov/pubmed/16469982" onclick="return gatrack(this);">around <span class="estimated_bodyfat_percent"></span>%</a>. The most accurate measurement would be a <a href="https://en.wikipedia.org/wiki/Dual_energy_X-ray_absorptiometry" onclick="return gatrack(this);">DEXA</a>. Skin fold measurement with <a href="https://www.amazon.com/gp/product/B0000AN3UB/ref=as_li_ss_tl?ie=UTF8&amp;camp=1789&amp;creative=390957&amp;creativeASIN=B0000AN3UB&amp;linkCode=as2&amp;tag=martanke-20" onclick="return gatrack(this);">a good caliper</a> is also pretty accurate. The easiest way is to just estimate it from some <a href="https://martin.ankerl.com/2016/01/04/body-fat-comparison-pictures/" onclick="return gatrack(this);">comparison pictures</a>. More: <a href="https://www.builtlean.com/2012/09/24/body-fat-percentage-men-women/" onclick="return gatrack(this);">1</a>, <a href="https://www.leighpeele.com/body-fat-pictures-and-percentages" onclick="return gatrack(this);">2</a>, <a href="https://www.nerdfitness.com/blog/2012/07/02/body-fat-percentage/" onclick="return gatrack(this);">3</a>. You can also try <a href="https://www.healthcentral.com/cholesterol/home-body-fat-test-2774-143.html" onclick="return gatrack(this);">this calculator</a> but that can be inaccurate.</p>',
     '<p>Finden wir deinen Körperfettanteil heraus. Basierend auf Größe und Gewicht liegt er vermutlich <a href="https://www.ncbi.nlm.nih.gov/pubmed/16469982" onclick="return gatrack(this);">bei etwa <span class="estimated_bodyfat_percent"></span>%</a>. Am genauesten misst ein <a href="https://en.wikipedia.org/wiki/Dual_energy_X-ray_absorptiometry" onclick="return gatrack(this);">DEXA-Scan</a>. Auch die Messung der Hautfalten mit <a href="https://www.amazon.com/gp/product/B0000AN3UB/ref=as_li_ss_tl?ie=UTF8&amp;camp=1789&amp;creative=390957&amp;creativeASIN=B0000AN3UB&amp;linkCode=as2&amp;tag=martanke-20" onclick="return gatrack(this);">einem guten Caliper</a> ist recht genau. Am einfachsten schätzt du ihn anhand von <a href="https://martin.ankerl.com/2016/01/04/body-fat-comparison-pictures/" onclick="return gatrack(this);">Vergleichsbildern</a>. Mehr: <a href="https://www.builtlean.com/2012/09/24/body-fat-percentage-men-women/" onclick="return gatrack(this);">1</a>, <a href="https://www.leighpeele.com/body-fat-pictures-and-percentages" onclick="return gatrack(this);">2</a>, <a href="https://www.nerdfitness.com/blog/2012/07/02/body-fat-percentage/" onclick="return gatrack(this);">3</a>. Du kannst auch <a href="https://www.healthcentral.com/cholesterol/home-body-fat-test-2774-143.html" onclick="return gatrack(this);">diesen Rechner</a> ausprobieren, der kann aber ungenau sein.</p>')
 
-rep('<input name="bodyfat" type="number" value="" placeholder="20"> % Body fat</li>',
-    '<input name="bodyfat" type="number" value="" placeholder="20"> % Körperfett</li>')
+rep('<input name="bodyfat" type="number" value="" placeholder="20" aria-label="Body fat percentage"> % Body fat</li>',
+    '<input name="bodyfat" type="number" value="" placeholder="20" aria-label="Körperfettanteil in Prozent"> % Körperfett</li>')
 
 rep('<p>With <span class="bodyfat_percentage"></span>% body fat you have <span class="lean_lbs"></span>lbs (<span class="lean_kg"></span>kg) of lean body mass, and <span class="fat_lbs"></span>lbs (<span class="fat_kg"></span>kg) of body fat. This includes about <span class="essential_fat_lbs"></span>lbs (<span class="essential_fat_kg"></span>kg) of <a href="https://en.wikipedia.org/wiki/Body_fat_percentage#Typical_body_fat_amounts" onclick="return gatrack(this);">essential body fat</a> that you must not lose.</p>',
     '<p>Bei <span class="bodyfat_percentage"></span>% Körperfett hast du <span class="lean_kg"></span>kg (<span class="lean_lbs"></span>lbs) fettfreie Masse und <span class="fat_kg"></span>kg (<span class="fat_lbs"></span>lbs) Körperfett. Davon sind etwa <span class="essential_fat_kg"></span>kg (<span class="essential_fat_lbs"></span>lbs) <a href="https://en.wikipedia.org/wiki/Body_fat_percentage#Typical_body_fat_amounts" onclick="return gatrack(this);">essentielles Körperfett</a>, das du nicht verlieren darfst.</p>')
@@ -195,8 +195,8 @@ rep('<summary>Net carbs vs. fiber — what actually counts?</summary>',
 rep('<p>Total carbohydrate is made up of net carbs plus fiber. Net carbs are the part that turns into glucose and raises your blood sugar — exactly what you want to limit on keto, which is why most people aim for 20–25g a day. Fiber is the rest, and it\'s good for you: insoluble fiber passes straight through without touching your blood sugar, while gut bacteria ferment soluble fiber into fatty acids that add only a few calories and don\'t spike glucose. That\'s why keto counts net carbs and lets fiber off the hook.</p>',
     '<p>Die Gesamt-Kohlenhydrate setzen sich aus Netto-Kohlenhydraten plus Ballaststoffen zusammen. Die Netto-Kohlenhydrate sind der Teil, der zu Glukose wird und deinen Blutzucker hebt — genau das willst du bei Keto begrenzen, weshalb die meisten 20–25g pro Tag anpeilen. Ballaststoffe sind der Rest und sie tun dir gut: unlösliche Ballaststoffe wandern unverändert hindurch, ohne den Blutzucker zu beeinflussen, während Darmbakterien lösliche Ballaststoffe zu Fettsäuren vergären, die nur wenige Kalorien liefern und den Blutzucker nicht ansteigen lassen. Deshalb zählt Keto die Netto-Kohlenhydrate und lässt die Ballaststoffe außen vor.</p>')
 
-rep('<input name="carbs" type="number" value="25"> g daily net carbs (changeable)</li>',
-    '<input name="carbs" type="number" value="25"> g Netto-Kohlenhydrate pro Tag (änderbar)</li>')
+rep('<input name="carbs" type="number" value="25" aria-label="Daily net carbs in grams"> g daily net carbs (changeable)</li>',
+    '<input name="carbs" type="number" value="25" aria-label="Tägliche Netto-Kohlenhydrate in Gramm"> g Netto-Kohlenhydrate pro Tag (änderbar)</li>')
 
 # Protein
 rep('<h3>How Much Protein Should I Eat?</h3>', '<h3>Wie viel Eiweiß sollte ich essen?</h3>')
@@ -284,14 +284,14 @@ rep('<p>Now to the fun stuff: a weight and body fat forecast for one year, start
     '<p>Jetzt zum spannenden Teil: eine Gewichts- und Körperfett-Prognose für ein Jahr ab heute. Denk daran, dass dies eine grobe Schätzung ist und deine persönlichen Ergebnisse abweichen können.</p>')
 rep('<p>Choose lbs or kg, and then play around with your chosen fat intake to see how it affects weight loss.</p>',
     '<p>Wähle kg oder lbs und spiele dann mit deiner gewählten Fettzufuhr, um zu sehen, wie sie den Gewichtsverlust beeinflusst.</p>')
-rep('<li>Start on <input id="graphstartdate" name="graphstartdate" type="date">.</li>',
-    '<li>Beginn am <input id="graphstartdate" name="graphstartdate" type="date">.</li>')
-rep('<li>Show in <input name="chart_weight_type" type="radio" value="1">lbs or <input name="chart_weight_type" type="radio" value="0">kg</li>',
-    '<li>Anzeigen in <input name="chart_weight_type" type="radio" value="0">kg oder <input name="chart_weight_type" type="radio" value="1">lbs</li>')
+rep('<li><label for="graphstartdate">Start on</label> <input id="graphstartdate" name="graphstartdate" type="date">.</li>',
+    '<li><label for="graphstartdate">Beginn am</label> <input id="graphstartdate" name="graphstartdate" type="date">.</li>')
+rep('<li>Show in <label><input name="chart_weight_type" type="radio" value="1">lbs</label> or <label><input name="chart_weight_type" type="radio" value="0">kg</label></li>',
+    '<li>Anzeigen in <label><input name="chart_weight_type" type="radio" value="0">kg</label> oder <label><input name="chart_weight_type" type="radio" value="1">lbs</label></li>')
 rep('Please enter a date and click lbs or kg to show the graph.',
     'Bitte gib ein Datum ein und klicke auf kg oder lbs, um die Grafik anzuzeigen.')
-rep('<p>For all you data junkies, you can <a id="csvdownload" download="KetoCalculatorForecast.csv" href="javascript:void(0)">download a CSV file of your projected weight loss</a>. This contains all the data used in the above graph.',
-    '<p>Für alle Daten-Fans: Du kannst <a id="csvdownload" download="KetoCalculatorForecast.csv" href="javascript:void(0)">eine CSV-Datei deines prognostizierten Gewichtsverlaufs herunterladen</a>. Sie enthält alle Daten der obigen Grafik.')
+rep('<p>For all you data junkies, you can <a id="csvdownload" download="KetoCalculatorForecast.csv">download a CSV file of your projected weight loss</a>. This contains all the data used in the above graph.',
+    '<p>Für alle Daten-Fans: Du kannst <a id="csvdownload" download="KetoCalculatorForecast.csv">eine CSV-Datei deines prognostizierten Gewichtsverlaufs herunterladen</a>. Sie enthält alle Daten der obigen Grafik.')
 
 # ---------------------------------------------------------------------------
 # 6. FAQ (visible <h3>/<p> AND JSON-LD name/text)
@@ -429,7 +429,7 @@ rep('<i class="sprite sprite-me" style="float:left; margin-right: 1em; margin-to
 # 8. JavaScript strings
 # ---------------------------------------------------------------------------
 # Created / last-reviewed line under the bio
-rep('<p style="font-size:smaller; color:#6b7a86; margin-top:0.6em;">Created October 2012 · last reviewed June 2026. The formulas are unchanged since publication and are reviewed periodically for accuracy.</p>',
+rep('<p style="font-size:smaller; color:#98a6b3; margin-top:0.6em;">Created October 2012 · last reviewed June 2026. The formulas are unchanged since publication and are reviewed periodically for accuracy.</p>',
     '<p style="font-size:smaller; color:#6b7a86; margin-top:0.6em;">Erstellt im Oktober 2012 · zuletzt überprüft im Juni 2026. Die Formeln sind seit der Veröffentlichung unverändert und werden regelmäßig auf Richtigkeit überprüft.</p>')
 
 # Food equivalents
@@ -499,6 +499,26 @@ rep('4: "Custom expenditure: "', '4: "Eigener Verbrauch: "')
 # share feedback
 rep("fb.textContent = ' Link copied to clipboard!';", "fb.textContent = ' Link in die Zwischenablage kopiert!';")
 rep("window.prompt('Copy your shareable link:', url);", "window.prompt('Kopiere deinen Teilen-Link:', url);", count=2)
+
+# ---------------------------------------------------------------------------
+# 8b. Screen-reader labels (aria-label) for inputs whose visible text is
+#     not programmatically associated with them
+# ---------------------------------------------------------------------------
+rep('aria-label="Base Metabolic Rate in kcal"', 'aria-label="Grundumsatz in kcal"')
+rep('aria-label="Daily energy expenditure in kcal"', 'aria-label="Täglicher Energieverbrauch in kcal"')
+rep('aria-label="Minimum protein in grams"', 'aria-label="Minimales Eiweiß in Gramm"')
+rep('aria-label="Chosen protein in grams"', 'aria-label="Gewähltes Eiweiß in Gramm"')
+rep('aria-label="Maximum protein in grams"', 'aria-label="Maximales Eiweiß in Gramm"')
+rep('aria-label="Minimum calorie deficit in percent"', 'aria-label="Minimales Kaloriendefizit in Prozent"')
+rep('aria-label="Chosen calorie deficit in percent"', 'aria-label="Gewähltes Kaloriendefizit in Prozent"')
+rep('aria-label="Calorie deficit at maintenance in percent"', 'aria-label="Kaloriendefizit bei Erhaltung in Prozent"')
+rep('aria-label="Minimum daily calories in kcal"', 'aria-label="Minimale tägliche Kalorien in kcal"')
+rep('aria-label="Chosen daily calories in kcal"', 'aria-label="Gewählte tägliche Kalorien in kcal"')
+rep('aria-label="Daily calories at maintenance in kcal"', 'aria-label="Tägliche Kalorien bei Erhaltung in kcal"')
+rep('aria-label="Minimum fat in grams"', 'aria-label="Minimales Fett in Gramm"')
+rep('aria-label="Chosen fat in grams"', 'aria-label="Gewähltes Fett in Gramm"')
+rep('aria-label="Maximum fat in grams"', 'aria-label="Maximales Fett in Gramm"')
+rep('aria-label="Reddit post text"', 'aria-label="Text für den Reddit-Beitrag"')
 
 # ---------------------------------------------------------------------------
 # 9. Dates need no localization anymore: the native <input type="date">

--- a/dev/build_de.py
+++ b/dev/build_de.py
@@ -146,23 +146,23 @@ rep('<h3>Determine Your Energy Expenditure</h3>', '<h3>Bestimme deinen Energieve
 rep('<p>Given that data, it is possible to calculate your <a href="https://en.wikipedia.org/wiki/Basal_metabolic_rate" onclick="return gatrack(this);">Base Metabolic Rate (BMR)</a>. This site uses the <a href="https://www.freedieting.com/calorie_needs.html" onclick="return gatrack(this);">Mifflin-St.Jeor-Formula</a> which was the most accurate in <a href="https://www.ncbi.nlm.nih.gov/pubmed/15883556" onclick="return gatrack(this);">two</a>&nbsp;<a href="https://www.ncbi.nlm.nih.gov/pubmed/18688113" onclick="return gatrack(this);">studies</a>.</p>',
     '<p>Mit diesen Daten lässt sich dein <a href="https://en.wikipedia.org/wiki/Basal_metabolic_rate" onclick="return gatrack(this);">Grundumsatz (BMR)</a> berechnen. Diese Seite verwendet die <a href="https://www.freedieting.com/calorie_needs.html" onclick="return gatrack(this);">Mifflin-St.-Jeor-Formel</a>, die in <a href="https://www.ncbi.nlm.nih.gov/pubmed/15883556" onclick="return gatrack(this);">zwei</a>&nbsp;<a href="https://www.ncbi.nlm.nih.gov/pubmed/18688113" onclick="return gatrack(this);">Studien</a> am genauesten war.</p>')
 
-rep('kcal Base Metabolic Rate</li>', 'kcal Grundumsatz</li>')
+rep('kcal Base Metabolic Rate</label></li>', 'kcal Grundumsatz</label></li>')
 
 rep("<p>The BMR resembles the resting metabolic rate. The real daily energy expenditure depends on how active you are on average. Based on that activity level we calculate your actual total daily energy expenditure (TDEE). This is the number of calories you need to consume each day when you do not want to lose weight.</p>",
     '<p>Der Grundumsatz entspricht in etwa dem Ruheumsatz. Dein tatsächlicher Tagesverbrauch hängt davon ab, wie aktiv du im Schnitt bist. Aus diesem Aktivitätsgrad berechnen wir deinen gesamten täglichen Energieverbrauch (TDEE). Das ist die Menge an Kalorien, die du täglich essen musst, wenn du dein Gewicht halten willst.</p>')
 
-rep('<tr><td><input name="level" type="radio" value="0" aria-label="Activity level: sedentary"></td><td>Sedentary. Typical desk job, little to no exercise.</td></tr>',
-    '<tr><td><input name="level" type="radio" value="0" aria-label="Aktivitätslevel: überwiegend sitzend"></td><td>Sitzend. Typischer Bürojob, kaum bis kein Sport.</td></tr>')
-rep('<tr><td><input name="level" type="radio" value="1" aria-label="Activity level: lightly active"></td><td>Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</td></tr>',
-    '<tr><td><input name="level" type="radio" value="1" aria-label="Aktivitätslevel: leicht aktiv"></td><td>Leicht aktiv. Viel auf den Beinen, z. B. im Einzelhandel. 1–3 Stunden leichter Sport pro Woche.</td></tr>')
-rep('<tr><td><input name="level" type="radio" value="2" aria-label="Activity level: moderately active"></td><td>Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</td></tr>',
-    '<tr><td><input name="level" type="radio" value="2" aria-label="Aktivitätslevel: mäßig aktiv"></td><td>Mäßig aktiv. 3–5 Stunden pro Woche, z. B. täglich 15 Minuten Rad fahren und 3-mal pro Woche Krafttraining.</td></tr>')
-rep('<tr><td><input name="level" type="radio" value="3" aria-label="Activity level: very active"></td><td>Very active. Construction workers, hard exercise 6–7 days per week</td></tr>',
-    '<tr><td><input name="level" type="radio" value="3" aria-label="Aktivitätslevel: sehr aktiv"></td><td>Sehr aktiv. Körperliche Arbeit, hartes Training an 6–7 Tagen pro Woche.</td></tr>')
+rep('<tr><td><input id="level0" name="level" type="radio" value="0"></td><td><label for="level0">Sedentary. Typical desk job, little to no exercise.</label></td></tr>',
+    '<tr><td><input id="level0" name="level" type="radio" value="0"></td><td><label for="level0">Sitzend. Typischer Bürojob, kaum bis kein Sport.</label></td></tr>')
+rep('<tr><td><input id="level1" name="level" type="radio" value="1"></td><td><label for="level1">Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</label></td></tr>',
+    '<tr><td><input id="level1" name="level" type="radio" value="1"></td><td><label for="level1">Leicht aktiv. Viel auf den Beinen, z. B. im Einzelhandel. 1–3 Stunden leichter Sport pro Woche.</label></td></tr>')
+rep('<tr><td><input id="level2" name="level" type="radio" value="2"></td><td><label for="level2">Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</label></td></tr>',
+    '<tr><td><input id="level2" name="level" type="radio" value="2"></td><td><label for="level2">Mäßig aktiv. 3–5 Stunden pro Woche, z. B. täglich 15 Minuten Rad fahren und 3-mal pro Woche Krafttraining.</label></td></tr>')
+rep('<tr><td><input id="level3" name="level" type="radio" value="3"></td><td><label for="level3">Very active. Construction workers, hard exercise 6–7 days per week</label></td></tr>',
+    '<tr><td><input id="level3" name="level" type="radio" value="3"></td><td><label for="level3">Sehr aktiv. Körperliche Arbeit, hartes Training an 6–7 Tagen pro Woche.</label></td></tr>')
 rep('<tr><td><input name="level" type="radio" value="4" aria-label="Activity level: custom"></td><td>Custom: <input disabled="disabled" name="custom_expenditure" type="number" value="" aria-label="Custom daily energy expenditure in kcal"> kcal</td></tr>',
     '<tr><td><input name="level" type="radio" value="4" aria-label="Aktivitätslevel: eigener Verbrauch"></td><td>Eigener Wert: <input disabled="disabled" name="custom_expenditure" type="number" value="" aria-label="Eigener täglicher Energieverbrauch in kcal"> kcal</td></tr>')
 
-rep('kcal daily energy expenditure</li>', 'kcal täglicher Energieverbrauch</li>')
+rep('kcal daily energy expenditure</label></li>', 'kcal täglicher Energieverbrauch</label></li>')
 
 # Body fat
 rep('<h3>How Much Body Fat do you Have?</h3>', '<h3>Wie hoch ist dein Körperfettanteil?</h3>')
@@ -170,8 +170,8 @@ rep('<h3>How Much Body Fat do you Have?</h3>', '<h3>Wie hoch ist dein Körperfet
 rep('<p>Let\'s find out your body fat percentage. Based on your height and weight, your body fat percentage might be <a href="https://www.ncbi.nlm.nih.gov/pubmed/16469982" onclick="return gatrack(this);">around <span class="estimated_bodyfat_percent"></span>%</a>. The most accurate measurement would be a <a href="https://en.wikipedia.org/wiki/Dual_energy_X-ray_absorptiometry" onclick="return gatrack(this);">DEXA</a>. Skin fold measurement with <a href="https://www.amazon.com/gp/product/B0000AN3UB/ref=as_li_ss_tl?ie=UTF8&amp;camp=1789&amp;creative=390957&amp;creativeASIN=B0000AN3UB&amp;linkCode=as2&amp;tag=martanke-20" onclick="return gatrack(this);">a good caliper</a> is also pretty accurate. The easiest way is to just estimate it from some <a href="https://martin.ankerl.com/2016/01/04/body-fat-comparison-pictures/" onclick="return gatrack(this);">comparison pictures</a>. More: <a href="https://www.builtlean.com/2012/09/24/body-fat-percentage-men-women/" onclick="return gatrack(this);">1</a>, <a href="https://www.leighpeele.com/body-fat-pictures-and-percentages" onclick="return gatrack(this);">2</a>, <a href="https://www.nerdfitness.com/blog/2012/07/02/body-fat-percentage/" onclick="return gatrack(this);">3</a>. You can also try <a href="https://www.healthcentral.com/cholesterol/home-body-fat-test-2774-143.html" onclick="return gatrack(this);">this calculator</a> but that can be inaccurate.</p>',
     '<p>Finden wir deinen Körperfettanteil heraus. Basierend auf Größe und Gewicht liegt er vermutlich <a href="https://www.ncbi.nlm.nih.gov/pubmed/16469982" onclick="return gatrack(this);">bei etwa <span class="estimated_bodyfat_percent"></span>%</a>. Am genauesten misst ein <a href="https://en.wikipedia.org/wiki/Dual_energy_X-ray_absorptiometry" onclick="return gatrack(this);">DEXA-Scan</a>. Auch die Messung der Hautfalten mit <a href="https://www.amazon.com/gp/product/B0000AN3UB/ref=as_li_ss_tl?ie=UTF8&amp;camp=1789&amp;creative=390957&amp;creativeASIN=B0000AN3UB&amp;linkCode=as2&amp;tag=martanke-20" onclick="return gatrack(this);">einem guten Caliper</a> ist recht genau. Am einfachsten schätzt du ihn anhand von <a href="https://martin.ankerl.com/2016/01/04/body-fat-comparison-pictures/" onclick="return gatrack(this);">Vergleichsbildern</a>. Mehr: <a href="https://www.builtlean.com/2012/09/24/body-fat-percentage-men-women/" onclick="return gatrack(this);">1</a>, <a href="https://www.leighpeele.com/body-fat-pictures-and-percentages" onclick="return gatrack(this);">2</a>, <a href="https://www.nerdfitness.com/blog/2012/07/02/body-fat-percentage/" onclick="return gatrack(this);">3</a>. Du kannst auch <a href="https://www.healthcentral.com/cholesterol/home-body-fat-test-2774-143.html" onclick="return gatrack(this);">diesen Rechner</a> ausprobieren, der kann aber ungenau sein.</p>')
 
-rep('<input name="bodyfat" type="number" value="" placeholder="20" aria-label="Body fat percentage"> % Body fat</li>',
-    '<input name="bodyfat" type="number" value="" placeholder="20" aria-label="Körperfettanteil in Prozent"> % Körperfett</li>')
+rep('<label><input name="bodyfat" type="number" value="" placeholder="20"> % Body fat</label></li>',
+    '<label><input name="bodyfat" type="number" value="" placeholder="20"> % Körperfett</label></li>')
 
 rep('<p>With <span class="bodyfat_percentage"></span>% body fat you have <span class="lean_lbs"></span>lbs (<span class="lean_kg"></span>kg) of lean body mass, and <span class="fat_lbs"></span>lbs (<span class="fat_kg"></span>kg) of body fat. This includes about <span class="essential_fat_lbs"></span>lbs (<span class="essential_fat_kg"></span>kg) of <a href="https://en.wikipedia.org/wiki/Body_fat_percentage#Typical_body_fat_amounts" onclick="return gatrack(this);">essential body fat</a> that you must not lose.</p>',
     '<p>Bei <span class="bodyfat_percentage"></span>% Körperfett hast du <span class="lean_kg"></span>kg (<span class="lean_lbs"></span>lbs) fettfreie Masse und <span class="fat_kg"></span>kg (<span class="fat_lbs"></span>lbs) Körperfett. Davon sind etwa <span class="essential_fat_kg"></span>kg (<span class="essential_fat_lbs"></span>lbs) <a href="https://en.wikipedia.org/wiki/Body_fat_percentage#Typical_body_fat_amounts" onclick="return gatrack(this);">essentielles Körperfett</a>, das du nicht verlieren darfst.</p>')
@@ -195,8 +195,8 @@ rep('<summary>Net carbs vs. fiber — what actually counts?</summary>',
 rep('<p>Total carbohydrate is made up of net carbs plus fiber. Net carbs are the part that turns into glucose and raises your blood sugar — exactly what you want to limit on keto, which is why most people aim for 20–25g a day. Fiber is the rest, and it\'s good for you: insoluble fiber passes straight through without touching your blood sugar, while gut bacteria ferment soluble fiber into fatty acids that add only a few calories and don\'t spike glucose. That\'s why keto counts net carbs and lets fiber off the hook.</p>',
     '<p>Die Gesamt-Kohlenhydrate setzen sich aus Netto-Kohlenhydraten plus Ballaststoffen zusammen. Die Netto-Kohlenhydrate sind der Teil, der zu Glukose wird und deinen Blutzucker hebt — genau das willst du bei Keto begrenzen, weshalb die meisten 20–25g pro Tag anpeilen. Ballaststoffe sind der Rest und sie tun dir gut: unlösliche Ballaststoffe wandern unverändert hindurch, ohne den Blutzucker zu beeinflussen, während Darmbakterien lösliche Ballaststoffe zu Fettsäuren vergären, die nur wenige Kalorien liefern und den Blutzucker nicht ansteigen lassen. Deshalb zählt Keto die Netto-Kohlenhydrate und lässt die Ballaststoffe außen vor.</p>')
 
-rep('<input name="carbs" type="number" value="25" aria-label="Daily net carbs in grams"> g daily net carbs (changeable)</li>',
-    '<input name="carbs" type="number" value="25" aria-label="Tägliche Netto-Kohlenhydrate in Gramm"> g Netto-Kohlenhydrate pro Tag (änderbar)</li>')
+rep('<label><input name="carbs" type="number" value="25"> g daily net carbs (changeable)</label></li>',
+    '<label><input name="carbs" type="number" value="25"> g Netto-Kohlenhydrate pro Tag (änderbar)</label></li>')
 
 # Protein
 rep('<h3>How Much Protein Should I Eat?</h3>', '<h3>Wie viel Eiweiß sollte ich essen?</h3>')
@@ -429,8 +429,10 @@ rep('<i class="sprite sprite-me" style="float:left; margin-right: 1em; margin-to
 # 8. JavaScript strings
 # ---------------------------------------------------------------------------
 # Created / last-reviewed line under the bio
-rep('<p style="font-size:smaller; color:#98a6b3; margin-top:0.6em;">Created October 2012 · last reviewed June 2026. The formulas are unchanged since publication and are reviewed periodically for accuracy.</p>',
-    '<p style="font-size:smaller; color:#6b7a86; margin-top:0.6em;">Erstellt im Oktober 2012 · zuletzt überprüft im Juni 2026. Die Formeln sind seit der Veröffentlichung unverändert und werden regelmäßig auf Richtigkeit überprüft.</p>')
+# Text-only on purpose: the <p style=...> wrapper flows through untranslated,
+# so a styling change on the English side can never desync the German page.
+rep('Created October 2012 · last reviewed June 2026. The formulas are unchanged since publication and are reviewed periodically for accuracy.',
+    'Erstellt im Oktober 2012 · zuletzt überprüft im Juni 2026. Die Formeln sind seit der Veröffentlichung unverändert und werden regelmäßig auf Richtigkeit überprüft.')
 
 # Food equivalents
 rep('var berries = Math.max(1, Math.round(carbs_g / 12));',
@@ -504,8 +506,7 @@ rep("window.prompt('Copy your shareable link:', url);", "window.prompt('Kopiere 
 # 8b. Screen-reader labels (aria-label) for inputs whose visible text is
 #     not programmatically associated with them
 # ---------------------------------------------------------------------------
-rep('aria-label="Base Metabolic Rate in kcal"', 'aria-label="Grundumsatz in kcal"')
-rep('aria-label="Daily energy expenditure in kcal"', 'aria-label="Täglicher Energieverbrauch in kcal"')
+rep('aria-label="Activity level"', 'aria-label="Aktivitätslevel"')
 rep('aria-label="Minimum protein in grams"', 'aria-label="Minimales Eiweiß in Gramm"')
 rep('aria-label="Chosen protein in grams"', 'aria-label="Gewähltes Eiweiß in Gramm"')
 rep('aria-label="Maximum protein in grams"', 'aria-label="Maximales Eiweiß in Gramm"')

--- a/dev/guides/template.html
+++ b/dev/guides/template.html
@@ -141,8 +141,9 @@
 		a{color:#0e6e96;text-decoration:none;transition:color .15s ease;}
 		a:visited{color:#0e6e96;}
 		a:hover,a:visited:hover{color:#0a5675;text-decoration:underline;}
-		/* In-text links must not rely on color alone (WCAG 1.4.1); nav/CTA links keep their own styling. */
-		#main p a,#main li a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
+		/* In-text links must not rely on color alone (WCAG 1.4.1). Masthead/CTA
+		   links keep their own styling; crumbs and footer links are opted in. */
+		#main p a,#main li a,#main td a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
 
 		/* masthead — the cyan brand bar, linked home */
 		#header{
@@ -265,7 +266,7 @@
 		table.examples caption{
 			caption-side:bottom;
 			font-size:13px;
-			color:#5f6e7a;
+			color:#5a6b78;
 			margin-top:8px;
 			text-align:left;
 			font-style:italic;

--- a/dev/guides/template.html
+++ b/dev/guides/template.html
@@ -141,6 +141,8 @@
 		a{color:#0e6e96;text-decoration:none;transition:color .15s ease;}
 		a:visited{color:#0e6e96;}
 		a:hover,a:visited:hover{color:#0a5675;text-decoration:underline;}
+		/* In-text links must not rely on color alone (WCAG 1.4.1); nav/CTA links keep their own styling. */
+		#main p a,#main li a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
 
 		/* masthead — the cyan brand bar, linked home */
 		#header{
@@ -263,7 +265,7 @@
 		table.examples caption{
 			caption-side:bottom;
 			font-size:13px;
-			color:#6b7a86;
+			color:#5f6e7a;
 			margin-top:8px;
 			text-align:left;
 			font-style:italic;

--- a/embed.html
+++ b/embed.html
@@ -730,6 +730,17 @@
 			text-decoration:none;
 		}
 
+		/* In-text links carry an underline so they don't rely on color alone
+		   (WCAG 1.4.1). Header/nav/CTA links keep their own styling. */
+		#main p a, #main li a, #main td a, #aboutmewidth a {
+			text-decoration: underline;
+			text-underline-offset: 2px;
+		}
+		/* On the dark footer the standard link blue falls below 4.5:1. */
+		#aboutmewidth a {
+			color:#5ab6e0;
+		}
+
 		a:hover,a:visited:hover
 		{
 			color:#0a5675;
@@ -983,7 +994,7 @@
 			color:#14202b;
 			margin:1px 0 4px;
 		}
-		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#7a8a96; }
+		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#566270; }
 		.pie-col > div[id^="pie_"] { display:inline-block; }
 
 		.recommended {
@@ -1451,7 +1462,7 @@
 		</div>
         
 		<div id="content">
-			<div id="main">
+			<div id="main" role="main">
                 <div id="broughttoyou">
                     Powered by <a href="https://keto-calculator.ankerl.com/">keto-calculator.ankerl.com</a> &middot; free keto macro calculator
                 </div>
@@ -1468,17 +1479,17 @@
 					<p>To get your personal customized recommendations, please enter some data about yourself.</p>
 					
 					<table class="userinputs">
-						<tr><td><input name="sex" tabindex="1" type="radio" value="1">Female <input name="sex" tabindex="2" type="radio" value="0">Male</td></tr>
+						<tr><td><label><input name="sex" type="radio" value="1">Female</label> <label><input name="sex" type="radio" value="0">Male</label></td></tr>
 
-						<tr><td><input name="lbs" tabindex="3" type="number" step="0.1" value="" placeholder="180"> lbs weight (<input name="kg" type="number" step="0.1" value=""> kg)
+						<tr><td><input name="lbs" type="number" step="0.1" value="" placeholder="180" aria-label="Weight in pounds"> lbs weight (<input name="kg" type="number" step="0.1" value="" aria-label="Weight in kilograms"> kg)
 						<div id="weight_warning"></div>
 						</td></tr>
 
-						<tr><td><input name="feet" tabindex="4" type="number" value="" step="1" style="width:3.4em" placeholder="5">' <input name="inch" tabindex="5" type="number" step="1" value="" style="width:3.8em" placeholder="9">" tall (<input name="height" type="number" value=""> cm)
+						<tr><td><input name="feet" type="number" value="" step="1" style="width:3.4em" placeholder="5" aria-label="Height: feet">' <input name="inch" type="number" step="1" value="" style="width:3.8em" placeholder="9" aria-label="Height: inches">" tall (<input name="height" type="number" value="" aria-label="Height in centimeters"> cm)
 						<div id="height_warning"></div>
 						</td></tr>
 
-							<tr><td>Date of birth: <input id="bday" name="bday" tabindex="6" type="date">
+							<tr><td><label for="bday">Date of birth:</label> <input id="bday" name="bday" type="date">
 							<div id="date_warning"></div>				
 						</td></tr>
 
@@ -1493,7 +1504,7 @@
 					<p>Given that data, it is possible to calculate your <a href="https://en.wikipedia.org/wiki/Basal_metabolic_rate" onclick="return gatrack(this);">Base Metabolic Rate (BMR)</a>. This site uses the <a href="https://www.freedieting.com/calorie_needs.html" onclick="return gatrack(this);">Mifflin-St.Jeor-Formula</a> which was the most accurate in <a href="https://www.ncbi.nlm.nih.gov/pubmed/15883556" onclick="return gatrack(this);">two</a>&nbsp;<a href="https://www.ncbi.nlm.nih.gov/pubmed/18688113" onclick="return gatrack(this);">studies</a>.</p>
 
 					<ul>
-						<li><input disabled="disabled" name="bmr" type="number" value=""> kcal Base Metabolic Rate</li>
+						<li><input disabled="disabled" name="bmr" type="number" value="" aria-label="Base Metabolic Rate in kcal"> kcal Base Metabolic Rate</li>
 					</ul>
 					
 					<p>The BMR resembles the resting metabolic rate. The real daily energy expenditure depends on how active you are on average. Based on that activity level we calculate your actual total daily energy expenditure (TDEE). This is the number of calories you need to consume each day when you do not want to lose weight.</p>
@@ -1501,17 +1512,17 @@
 					<ul>
 						<li>
 							<table>
-								<tr><td><input name="level" type="radio" value="0"></td><td>Sedentary. Typical desk job, little to no exercise.</td></tr>
-								<tr><td><input name="level" type="radio" value="1"></td><td>Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</td></tr>
-								<tr><td><input name="level" type="radio" value="2"></td><td>Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</td></tr>
-								<tr><td><input name="level" type="radio" value="3"></td><td>Very active. Construction workers, hard exercise 6–7 days per week</td></tr>
-								<tr><td><input name="level" type="radio" value="4"></td><td>Custom: <input disabled="disabled" name="custom_expenditure" type="number" value=""> kcal</td></tr>
+								<tr><td><input name="level" type="radio" value="0" aria-label="Activity level: sedentary"></td><td>Sedentary. Typical desk job, little to no exercise.</td></tr>
+								<tr><td><input name="level" type="radio" value="1" aria-label="Activity level: lightly active"></td><td>Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</td></tr>
+								<tr><td><input name="level" type="radio" value="2" aria-label="Activity level: moderately active"></td><td>Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</td></tr>
+								<tr><td><input name="level" type="radio" value="3" aria-label="Activity level: very active"></td><td>Very active. Construction workers, hard exercise 6–7 days per week</td></tr>
+								<tr><td><input name="level" type="radio" value="4" aria-label="Activity level: custom"></td><td>Custom: <input disabled="disabled" name="custom_expenditure" type="number" value="" aria-label="Custom daily energy expenditure in kcal"> kcal</td></tr>
 							</table>
 						</li>
 					</ul>
 
 					<ul>
-						<li><input disabled="disabled" name="energy" type="number" value=""> kcal daily energy expenditure</li>
+						<li><input disabled="disabled" name="energy" type="number" value="" aria-label="Daily energy expenditure in kcal"> kcal daily energy expenditure</li>
 					</ul>
 
 
@@ -1521,7 +1532,7 @@
 					<p>Let's find out your body fat percentage. Based on your height and weight, your body fat percentage might be <a href="https://www.ncbi.nlm.nih.gov/pubmed/16469982" onclick="return gatrack(this);">around <span class="estimated_bodyfat_percent"></span>%</a>. The most accurate measurement would be a <a href="https://en.wikipedia.org/wiki/Dual_energy_X-ray_absorptiometry" onclick="return gatrack(this);">DEXA</a>. Skin fold measurement with <a href="https://www.amazon.com/gp/product/B0000AN3UB/ref=as_li_ss_tl?ie=UTF8&amp;camp=1789&amp;creative=390957&amp;creativeASIN=B0000AN3UB&amp;linkCode=as2&amp;tag=martanke-20" onclick="return gatrack(this);">a good caliper</a> is also pretty accurate. The easiest way is to just estimate it from some <a href="https://martin.ankerl.com/2016/01/04/body-fat-comparison-pictures/" onclick="return gatrack(this);">comparison pictures</a>. More: <a href="https://www.builtlean.com/2012/09/24/body-fat-percentage-men-women/" onclick="return gatrack(this);">1</a>, <a href="https://www.leighpeele.com/body-fat-pictures-and-percentages" onclick="return gatrack(this);">2</a>, <a href="https://www.nerdfitness.com/blog/2012/07/02/body-fat-percentage/" onclick="return gatrack(this);">3</a>. You can also try <a href="https://www.healthcentral.com/cholesterol/home-body-fat-test-2774-143.html" onclick="return gatrack(this);">this calculator</a> but that can be inaccurate.</p>
 
 					<ul>
-						<li><input name="bodyfat" type="number" value="" placeholder="20"> % Body fat</li>
+						<li><input name="bodyfat" type="number" value="" placeholder="20" aria-label="Body fat percentage"> % Body fat</li>
 					</ul>
 
 					<p>With <span class="bodyfat_percentage"></span>% body fat you have <span class="lean_lbs"></span>lbs (<span class="lean_kg"></span>kg) of lean body mass, and <span class="fat_lbs"></span>lbs (<span class="fat_kg"></span>kg) of body fat. This includes about <span class="essential_fat_lbs"></span>lbs (<span class="essential_fat_kg"></span>kg) of <a href="https://en.wikipedia.org/wiki/Body_fat_percentage#Typical_body_fat_amounts" onclick="return gatrack(this);">essential body fat</a> that you must not lose.</p>
@@ -1545,7 +1556,7 @@
 
 
 					<ul>
-						<li><input name="carbs" type="number" value="25"> g daily net carbs (changeable)</li>
+						<li><input name="carbs" type="number" value="25" aria-label="Daily net carbs in grams"> g daily net carbs (changeable)</li>
 					</ul>
 					
 
@@ -1578,13 +1589,13 @@
 								</tr>
 
 								<tr>
-									<td><input disabled="disabled" name="protein_min" type="number" value="">
+									<td><input disabled="disabled" name="protein_min" type="number" value="" aria-label="Minimum protein in grams">
 									g&nbsp;minimum</td>
 
-									<td><input name="protein_chosen" type="number" value="">
+									<td><input name="protein_chosen" type="number" value="" aria-label="Chosen protein in grams">
 									g&nbsp;chosen</td>
 
-									<td><input disabled="disabled" name="protein_max" type="number" value="">
+									<td><input disabled="disabled" name="protein_max" type="number" value="" aria-label="Maximum protein in grams">
 									g&nbsp;maximum</td>
 								</tr>
 
@@ -1639,35 +1650,35 @@
 								</tr>
 								
 								<tr>
-									<td><input disabled="disabled" name="min_deficit_percent_form" type="number" value="">
+									<td><input disabled="disabled" name="min_deficit_percent_form" type="number" value="" aria-label="Minimum calorie deficit in percent">
 									%&nbsp;deficit</td>
 
-									<td><input name="target_deficit_form" type="number" value="">
+									<td><input name="target_deficit_form" type="number" value="" aria-label="Chosen calorie deficit in percent">
 									%&nbsp;deficit</td>
 
-									<td><input disabled="disabled" type="number" value="0">
+									<td><input disabled="disabled" type="number" value="0" aria-label="Calorie deficit at maintenance in percent">
 									%&nbsp;deficit</td>
 								</tr>										
 								
 								<tr>
-									<td width="33%"><input disabled="disabled" name="kcal_min_form" type="number" value="">
+									<td width="33%"><input disabled="disabled" name="kcal_min_form" type="number" value="" aria-label="Minimum daily calories in kcal">
 									kcal&nbsp;min</td>
 
-									<td width="33%"><input name="target_kcal_form" type="number" value="">
+									<td width="33%"><input name="target_kcal_form" type="number" value="" aria-label="Chosen daily calories in kcal">
 									kcal&nbsp;chosen</td>
 
-									<td><input disabled="disabled" name="kcal_max_form" type="number" value="">
+									<td><input disabled="disabled" name="kcal_max_form" type="number" value="" aria-label="Daily calories at maintenance in kcal">
 									kcal&nbsp;max</td>
 								</tr>
 								
 								<tr>
-									<td><input disabled="disabled" name="fat_min_form" type="number" value="">
+									<td><input disabled="disabled" name="fat_min_form" type="number" value="" aria-label="Minimum fat in grams">
 									g&nbsp;fat&nbsp;min</td>
 
-									<td><input name="target_fat_form" type="number" value="">
+									<td><input name="target_fat_form" type="number" value="" aria-label="Chosen fat in grams">
 									g&nbsp;fat&nbsp;chosen</td>
 
-									<td><input disabled="disabled" name="fat_max_form" type="number" value="">
+									<td><input disabled="disabled" name="fat_max_form" type="number" value="" aria-label="Maximum fat in grams">
 									g&nbsp;fat&nbsp;max</td>
 								</tr>										
 								
@@ -1780,9 +1791,9 @@
                         
 						<p>
 						<ul>
-						<li>Start on <input id="graphstartdate" name="graphstartdate" type="date">.</li>
+						<li><label for="graphstartdate">Start on</label> <input id="graphstartdate" name="graphstartdate" type="date">.</li>
 					
-						<li>Show in <input name="chart_weight_type" type="radio" value="1">lbs or <input name="chart_weight_type" type="radio" value="0">kg</li>
+						<li>Show in <label><input name="chart_weight_type" type="radio" value="1">lbs</label> or <label><input name="chart_weight_type" type="radio" value="0">kg</label></li>
 						</ul></p>
 
 						<div id="chart">
@@ -1791,7 +1802,7 @@
 							</div>
 						</div>
                         
-						<p>For all you data junkies, you can <a id="csvdownload" download="KetoCalculatorForecast.csv" href="javascript:void(0)">download a CSV file of your projected weight loss</a>. This contains all the data used in the above graph.
+						<p>For all you data junkies, you can <a id="csvdownload" download="KetoCalculatorForecast.csv">download a CSV file of your projected weight loss</a>. This contains all the data used in the above graph.
                     </div>
 
 					

--- a/embed.html
+++ b/embed.html
@@ -738,7 +738,7 @@
 		}
 		/* On the dark footer the standard link blue falls below 4.5:1. */
 		#aboutmewidth a {
-			color:#5ab6e0;
+			color:#7fc7e6;
 		}
 
 		a:hover,a:visited:hover
@@ -923,7 +923,7 @@
 			color:#14202b;
 			min-width:62px;
 		}
-		.macro-val i { font-size:14px; font-style:normal; font-weight:500; color:#7a8a96; margin-left:1px; }
+		.macro-val i { font-size:14px; font-style:normal; font-weight:500; color:#5a6b78; margin-left:1px; }
 		.macro-name {
 			font-family:'Space Grotesk','Helvetica Neue',Arial,sans-serif;
 			font-weight:600;
@@ -934,7 +934,7 @@
 		.macro-meta {
 			font-family:'Space Grotesk','Helvetica Neue',Arial,sans-serif;
 			font-size:12.5px;
-			color:#6b7a86;
+			color:#5a6b78;
 			white-space:nowrap;
 		}
 
@@ -960,7 +960,7 @@
 			font-family:'PT Serif',Georgia,'Times New Roman',serif;
 			font-size:13px;
 			font-style:italic;
-			color:#6b7a86;
+			color:#5a6b78;
 			margin:14px 0 0;
 			padding-top:13px;
 			border-top:1px solid #dce8f0;
@@ -994,7 +994,7 @@
 			color:#14202b;
 			margin:1px 0 4px;
 		}
-		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#566270; }
+		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#5a6b78; }
 		.pie-col > div[id^="pie_"] { display:inline-block; }
 
 		.recommended {
@@ -1433,8 +1433,7 @@
 	<style>
 	a:focus-visible,
 	button:focus-visible,
-	summary:focus-visible,
-	[tabindex]:focus-visible {
+	summary:focus-visible {
 		outline: 3px solid rgba(18,148,200,0.65);
 		outline-offset: 2px;
 		border-radius: 4px;
@@ -1462,7 +1461,7 @@
 		</div>
         
 		<div id="content">
-			<div id="main" role="main">
+			<main id="main">
                 <div id="broughttoyou">
                     Powered by <a href="https://keto-calculator.ankerl.com/">keto-calculator.ankerl.com</a> &middot; free keto macro calculator
                 </div>
@@ -1504,25 +1503,25 @@
 					<p>Given that data, it is possible to calculate your <a href="https://en.wikipedia.org/wiki/Basal_metabolic_rate" onclick="return gatrack(this);">Base Metabolic Rate (BMR)</a>. This site uses the <a href="https://www.freedieting.com/calorie_needs.html" onclick="return gatrack(this);">Mifflin-St.Jeor-Formula</a> which was the most accurate in <a href="https://www.ncbi.nlm.nih.gov/pubmed/15883556" onclick="return gatrack(this);">two</a>&nbsp;<a href="https://www.ncbi.nlm.nih.gov/pubmed/18688113" onclick="return gatrack(this);">studies</a>.</p>
 
 					<ul>
-						<li><input disabled="disabled" name="bmr" type="number" value="" aria-label="Base Metabolic Rate in kcal"> kcal Base Metabolic Rate</li>
+						<li><label><input disabled="disabled" name="bmr" type="number" value=""> kcal Base Metabolic Rate</label></li>
 					</ul>
 					
 					<p>The BMR resembles the resting metabolic rate. The real daily energy expenditure depends on how active you are on average. Based on that activity level we calculate your actual total daily energy expenditure (TDEE). This is the number of calories you need to consume each day when you do not want to lose weight.</p>
 					
 					<ul>
 						<li>
-							<table>
-								<tr><td><input name="level" type="radio" value="0" aria-label="Activity level: sedentary"></td><td>Sedentary. Typical desk job, little to no exercise.</td></tr>
-								<tr><td><input name="level" type="radio" value="1" aria-label="Activity level: lightly active"></td><td>Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</td></tr>
-								<tr><td><input name="level" type="radio" value="2" aria-label="Activity level: moderately active"></td><td>Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</td></tr>
-								<tr><td><input name="level" type="radio" value="3" aria-label="Activity level: very active"></td><td>Very active. Construction workers, hard exercise 6–7 days per week</td></tr>
+							<table role="radiogroup" aria-label="Activity level">
+								<tr><td><input id="level0" name="level" type="radio" value="0"></td><td><label for="level0">Sedentary. Typical desk job, little to no exercise.</label></td></tr>
+								<tr><td><input id="level1" name="level" type="radio" value="1"></td><td><label for="level1">Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</label></td></tr>
+								<tr><td><input id="level2" name="level" type="radio" value="2"></td><td><label for="level2">Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</label></td></tr>
+								<tr><td><input id="level3" name="level" type="radio" value="3"></td><td><label for="level3">Very active. Construction workers, hard exercise 6–7 days per week</label></td></tr>
 								<tr><td><input name="level" type="radio" value="4" aria-label="Activity level: custom"></td><td>Custom: <input disabled="disabled" name="custom_expenditure" type="number" value="" aria-label="Custom daily energy expenditure in kcal"> kcal</td></tr>
 							</table>
 						</li>
 					</ul>
 
 					<ul>
-						<li><input disabled="disabled" name="energy" type="number" value="" aria-label="Daily energy expenditure in kcal"> kcal daily energy expenditure</li>
+						<li><label><input disabled="disabled" name="energy" type="number" value=""> kcal daily energy expenditure</label></li>
 					</ul>
 
 
@@ -1532,7 +1531,7 @@
 					<p>Let's find out your body fat percentage. Based on your height and weight, your body fat percentage might be <a href="https://www.ncbi.nlm.nih.gov/pubmed/16469982" onclick="return gatrack(this);">around <span class="estimated_bodyfat_percent"></span>%</a>. The most accurate measurement would be a <a href="https://en.wikipedia.org/wiki/Dual_energy_X-ray_absorptiometry" onclick="return gatrack(this);">DEXA</a>. Skin fold measurement with <a href="https://www.amazon.com/gp/product/B0000AN3UB/ref=as_li_ss_tl?ie=UTF8&amp;camp=1789&amp;creative=390957&amp;creativeASIN=B0000AN3UB&amp;linkCode=as2&amp;tag=martanke-20" onclick="return gatrack(this);">a good caliper</a> is also pretty accurate. The easiest way is to just estimate it from some <a href="https://martin.ankerl.com/2016/01/04/body-fat-comparison-pictures/" onclick="return gatrack(this);">comparison pictures</a>. More: <a href="https://www.builtlean.com/2012/09/24/body-fat-percentage-men-women/" onclick="return gatrack(this);">1</a>, <a href="https://www.leighpeele.com/body-fat-pictures-and-percentages" onclick="return gatrack(this);">2</a>, <a href="https://www.nerdfitness.com/blog/2012/07/02/body-fat-percentage/" onclick="return gatrack(this);">3</a>. You can also try <a href="https://www.healthcentral.com/cholesterol/home-body-fat-test-2774-143.html" onclick="return gatrack(this);">this calculator</a> but that can be inaccurate.</p>
 
 					<ul>
-						<li><input name="bodyfat" type="number" value="" placeholder="20" aria-label="Body fat percentage"> % Body fat</li>
+						<li><label><input name="bodyfat" type="number" value="" placeholder="20"> % Body fat</label></li>
 					</ul>
 
 					<p>With <span class="bodyfat_percentage"></span>% body fat you have <span class="lean_lbs"></span>lbs (<span class="lean_kg"></span>kg) of lean body mass, and <span class="fat_lbs"></span>lbs (<span class="fat_kg"></span>kg) of body fat. This includes about <span class="essential_fat_lbs"></span>lbs (<span class="essential_fat_kg"></span>kg) of <a href="https://en.wikipedia.org/wiki/Body_fat_percentage#Typical_body_fat_amounts" onclick="return gatrack(this);">essential body fat</a> that you must not lose.</p>
@@ -1556,7 +1555,7 @@
 
 
 					<ul>
-						<li><input name="carbs" type="number" value="25" aria-label="Daily net carbs in grams"> g daily net carbs (changeable)</li>
+						<li><label><input name="carbs" type="number" value="25"> g daily net carbs (changeable)</label></li>
 					</ul>
 					
 
@@ -1812,7 +1811,7 @@
 					<textarea name="reddit_copypaste" readonly="readonly" style="display:none" aria-hidden="true"></textarea>
 
 					</form>
-			</div>
+			</main>
 
 			
 			

--- a/how-fast-will-i-lose-weight-on-keto.html
+++ b/how-fast-will-i-lose-weight-on-keto.html
@@ -148,8 +148,9 @@
 		a{color:#0e6e96;text-decoration:none;transition:color .15s ease;}
 		a:visited{color:#0e6e96;}
 		a:hover,a:visited:hover{color:#0a5675;text-decoration:underline;}
-		/* In-text links must not rely on color alone (WCAG 1.4.1); nav/CTA links keep their own styling. */
-		#main p a,#main li a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
+		/* In-text links must not rely on color alone (WCAG 1.4.1). Masthead/CTA
+		   links keep their own styling; crumbs and footer links are opted in. */
+		#main p a,#main li a,#main td a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
 
 		/* masthead — the cyan brand bar, linked home */
 		#header{
@@ -272,7 +273,7 @@
 		table.examples caption{
 			caption-side:bottom;
 			font-size:13px;
-			color:#5f6e7a;
+			color:#5a6b78;
 			margin-top:8px;
 			text-align:left;
 			font-style:italic;

--- a/how-fast-will-i-lose-weight-on-keto.html
+++ b/how-fast-will-i-lose-weight-on-keto.html
@@ -148,6 +148,8 @@
 		a{color:#0e6e96;text-decoration:none;transition:color .15s ease;}
 		a:visited{color:#0e6e96;}
 		a:hover,a:visited:hover{color:#0a5675;text-decoration:underline;}
+		/* In-text links must not rely on color alone (WCAG 1.4.1); nav/CTA links keep their own styling. */
+		#main p a,#main li a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
 
 		/* masthead — the cyan brand bar, linked home */
 		#header{
@@ -270,7 +272,7 @@
 		table.examples caption{
 			caption-side:bottom;
 			font-size:13px;
-			color:#6b7a86;
+			color:#5f6e7a;
 			margin-top:8px;
 			text-align:left;
 			font-style:italic;

--- a/how-much-protein-on-keto.html
+++ b/how-much-protein-on-keto.html
@@ -148,8 +148,9 @@
 		a{color:#0e6e96;text-decoration:none;transition:color .15s ease;}
 		a:visited{color:#0e6e96;}
 		a:hover,a:visited:hover{color:#0a5675;text-decoration:underline;}
-		/* In-text links must not rely on color alone (WCAG 1.4.1); nav/CTA links keep their own styling. */
-		#main p a,#main li a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
+		/* In-text links must not rely on color alone (WCAG 1.4.1). Masthead/CTA
+		   links keep their own styling; crumbs and footer links are opted in. */
+		#main p a,#main li a,#main td a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
 
 		/* masthead — the cyan brand bar, linked home */
 		#header{
@@ -272,7 +273,7 @@
 		table.examples caption{
 			caption-side:bottom;
 			font-size:13px;
-			color:#5f6e7a;
+			color:#5a6b78;
 			margin-top:8px;
 			text-align:left;
 			font-style:italic;

--- a/how-much-protein-on-keto.html
+++ b/how-much-protein-on-keto.html
@@ -148,6 +148,8 @@
 		a{color:#0e6e96;text-decoration:none;transition:color .15s ease;}
 		a:visited{color:#0e6e96;}
 		a:hover,a:visited:hover{color:#0a5675;text-decoration:underline;}
+		/* In-text links must not rely on color alone (WCAG 1.4.1); nav/CTA links keep their own styling. */
+		#main p a,#main li a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
 
 		/* masthead — the cyan brand bar, linked home */
 		#header{
@@ -270,7 +272,7 @@
 		table.examples caption{
 			caption-side:bottom;
 			font-size:13px;
-			color:#6b7a86;
+			color:#5f6e7a;
 			margin-top:8px;
 			text-align:left;
 			font-style:italic;

--- a/index.html
+++ b/index.html
@@ -789,6 +789,17 @@
 			text-decoration:none;
 		}
 
+		/* In-text links carry an underline so they don't rely on color alone
+		   (WCAG 1.4.1). Header/nav/CTA links keep their own styling. */
+		#main p a, #main li a, #main td a, #aboutmewidth a {
+			text-decoration: underline;
+			text-underline-offset: 2px;
+		}
+		/* On the dark footer the standard link blue falls below 4.5:1. */
+		#aboutmewidth a {
+			color:#5ab6e0;
+		}
+
 		a:hover,a:visited:hover
 		{
 			color:#0a5675;
@@ -1042,7 +1053,7 @@
 			color:#14202b;
 			margin:1px 0 4px;
 		}
-		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#7a8a96; }
+		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#566270; }
 		.pie-col > div[id^="pie_"] { display:inline-block; }
 
 		.recommended {
@@ -1500,7 +1511,7 @@
 		</div>
         
 		<div id="content">
-			<div id="main">
+			<div id="main" role="main">
                 <div id="broughttoyou">
                     By <a href="https://keto-calculator.ankerl.com/">keto-calculator.ankerl.com</a> &middot; <a href="de/" hreflang="de">Deutsch</a>
                 </div>
@@ -1529,17 +1540,17 @@
 					<p>To get your personal customized recommendations, please enter some data about yourself.</p>
 					
 					<table class="userinputs">
-						<tr><td><input name="sex" tabindex="1" type="radio" value="1">Female <input name="sex" tabindex="2" type="radio" value="0">Male</td></tr>
+						<tr><td><label><input name="sex" type="radio" value="1">Female</label> <label><input name="sex" type="radio" value="0">Male</label></td></tr>
 
-						<tr><td><input name="lbs" tabindex="3" type="number" step="0.1" value="" placeholder="180"> lbs weight (<input name="kg" type="number" step="0.1" value=""> kg)
+						<tr><td><input name="lbs" type="number" step="0.1" value="" placeholder="180" aria-label="Weight in pounds"> lbs weight (<input name="kg" type="number" step="0.1" value="" aria-label="Weight in kilograms"> kg)
 						<div id="weight_warning"></div>
 						</td></tr>
 
-						<tr><td><input name="feet" tabindex="4" type="number" value="" step="1" style="width:3.4em" placeholder="5">' <input name="inch" tabindex="5" type="number" step="1" value="" style="width:3.8em" placeholder="9">" tall (<input name="height" type="number" value=""> cm)
+						<tr><td><input name="feet" type="number" value="" step="1" style="width:3.4em" placeholder="5" aria-label="Height: feet">' <input name="inch" type="number" step="1" value="" style="width:3.8em" placeholder="9" aria-label="Height: inches">" tall (<input name="height" type="number" value="" aria-label="Height in centimeters"> cm)
 						<div id="height_warning"></div>
 						</td></tr>
 
-							<tr><td>Date of birth: <input id="bday" name="bday" tabindex="6" type="date">
+							<tr><td><label for="bday">Date of birth:</label> <input id="bday" name="bday" type="date">
 							<div id="date_warning"></div>				
 						</td></tr>
 
@@ -1554,7 +1565,7 @@
 					<p>Given that data, it is possible to calculate your <a href="https://en.wikipedia.org/wiki/Basal_metabolic_rate" onclick="return gatrack(this);">Base Metabolic Rate (BMR)</a>. This site uses the <a href="https://www.freedieting.com/calorie_needs.html" onclick="return gatrack(this);">Mifflin-St.Jeor-Formula</a> which was the most accurate in <a href="https://www.ncbi.nlm.nih.gov/pubmed/15883556" onclick="return gatrack(this);">two</a>&nbsp;<a href="https://www.ncbi.nlm.nih.gov/pubmed/18688113" onclick="return gatrack(this);">studies</a>.</p>
 
 					<ul>
-						<li><input disabled="disabled" name="bmr" type="number" value=""> kcal Base Metabolic Rate</li>
+						<li><input disabled="disabled" name="bmr" type="number" value="" aria-label="Base Metabolic Rate in kcal"> kcal Base Metabolic Rate</li>
 					</ul>
 					
 					<p>The BMR resembles the resting metabolic rate. The real daily energy expenditure depends on how active you are on average. Based on that activity level we calculate your actual total daily energy expenditure (TDEE). This is the number of calories you need to consume each day when you do not want to lose weight.</p>
@@ -1562,17 +1573,17 @@
 					<ul>
 						<li>
 							<table>
-								<tr><td><input name="level" type="radio" value="0"></td><td>Sedentary. Typical desk job, little to no exercise.</td></tr>
-								<tr><td><input name="level" type="radio" value="1"></td><td>Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</td></tr>
-								<tr><td><input name="level" type="radio" value="2"></td><td>Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</td></tr>
-								<tr><td><input name="level" type="radio" value="3"></td><td>Very active. Construction workers, hard exercise 6–7 days per week</td></tr>
-								<tr><td><input name="level" type="radio" value="4"></td><td>Custom: <input disabled="disabled" name="custom_expenditure" type="number" value=""> kcal</td></tr>
+								<tr><td><input name="level" type="radio" value="0" aria-label="Activity level: sedentary"></td><td>Sedentary. Typical desk job, little to no exercise.</td></tr>
+								<tr><td><input name="level" type="radio" value="1" aria-label="Activity level: lightly active"></td><td>Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</td></tr>
+								<tr><td><input name="level" type="radio" value="2" aria-label="Activity level: moderately active"></td><td>Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</td></tr>
+								<tr><td><input name="level" type="radio" value="3" aria-label="Activity level: very active"></td><td>Very active. Construction workers, hard exercise 6–7 days per week</td></tr>
+								<tr><td><input name="level" type="radio" value="4" aria-label="Activity level: custom"></td><td>Custom: <input disabled="disabled" name="custom_expenditure" type="number" value="" aria-label="Custom daily energy expenditure in kcal"> kcal</td></tr>
 							</table>
 						</li>
 					</ul>
 
 					<ul>
-						<li><input disabled="disabled" name="energy" type="number" value=""> kcal daily energy expenditure</li>
+						<li><input disabled="disabled" name="energy" type="number" value="" aria-label="Daily energy expenditure in kcal"> kcal daily energy expenditure</li>
 					</ul>
 
 
@@ -1582,7 +1593,7 @@
 					<p>Let's find out your body fat percentage. Based on your height and weight, your body fat percentage might be <a href="https://www.ncbi.nlm.nih.gov/pubmed/16469982" onclick="return gatrack(this);">around <span class="estimated_bodyfat_percent"></span>%</a>. The most accurate measurement would be a <a href="https://en.wikipedia.org/wiki/Dual_energy_X-ray_absorptiometry" onclick="return gatrack(this);">DEXA</a>. Skin fold measurement with <a href="https://www.amazon.com/gp/product/B0000AN3UB/ref=as_li_ss_tl?ie=UTF8&amp;camp=1789&amp;creative=390957&amp;creativeASIN=B0000AN3UB&amp;linkCode=as2&amp;tag=martanke-20" onclick="return gatrack(this);">a good caliper</a> is also pretty accurate. The easiest way is to just estimate it from some <a href="https://martin.ankerl.com/2016/01/04/body-fat-comparison-pictures/" onclick="return gatrack(this);">comparison pictures</a>. More: <a href="https://www.builtlean.com/2012/09/24/body-fat-percentage-men-women/" onclick="return gatrack(this);">1</a>, <a href="https://www.leighpeele.com/body-fat-pictures-and-percentages" onclick="return gatrack(this);">2</a>, <a href="https://www.nerdfitness.com/blog/2012/07/02/body-fat-percentage/" onclick="return gatrack(this);">3</a>. You can also try <a href="https://www.healthcentral.com/cholesterol/home-body-fat-test-2774-143.html" onclick="return gatrack(this);">this calculator</a> but that can be inaccurate.</p>
 
 					<ul>
-						<li><input name="bodyfat" type="number" value="" placeholder="20"> % Body fat</li>
+						<li><input name="bodyfat" type="number" value="" placeholder="20" aria-label="Body fat percentage"> % Body fat</li>
 					</ul>
 
 					<p>With <span class="bodyfat_percentage"></span>% body fat you have <span class="lean_lbs"></span>lbs (<span class="lean_kg"></span>kg) of lean body mass, and <span class="fat_lbs"></span>lbs (<span class="fat_kg"></span>kg) of body fat. This includes about <span class="essential_fat_lbs"></span>lbs (<span class="essential_fat_kg"></span>kg) of <a href="https://en.wikipedia.org/wiki/Body_fat_percentage#Typical_body_fat_amounts" onclick="return gatrack(this);">essential body fat</a> that you must not lose.</p>
@@ -1616,7 +1627,7 @@
 
 
 					<ul>
-						<li><input name="carbs" type="number" value="25"> g daily net carbs (changeable)</li>
+						<li><input name="carbs" type="number" value="25" aria-label="Daily net carbs in grams"> g daily net carbs (changeable)</li>
 					</ul>
 					
 
@@ -1649,13 +1660,13 @@
 								</tr>
 
 								<tr>
-									<td><input disabled="disabled" name="protein_min" type="number" value="">
+									<td><input disabled="disabled" name="protein_min" type="number" value="" aria-label="Minimum protein in grams">
 									g&nbsp;minimum</td>
 
-									<td><input name="protein_chosen" type="number" value="">
+									<td><input name="protein_chosen" type="number" value="" aria-label="Chosen protein in grams">
 									g&nbsp;chosen</td>
 
-									<td><input disabled="disabled" name="protein_max" type="number" value="">
+									<td><input disabled="disabled" name="protein_max" type="number" value="" aria-label="Maximum protein in grams">
 									g&nbsp;maximum</td>
 								</tr>
 
@@ -1710,35 +1721,35 @@
 								</tr>
 								
 								<tr>
-									<td><input disabled="disabled" name="min_deficit_percent_form" type="number" value="">
+									<td><input disabled="disabled" name="min_deficit_percent_form" type="number" value="" aria-label="Minimum calorie deficit in percent">
 									%&nbsp;deficit</td>
 
-									<td><input name="target_deficit_form" type="number" value="">
+									<td><input name="target_deficit_form" type="number" value="" aria-label="Chosen calorie deficit in percent">
 									%&nbsp;deficit</td>
 
-									<td><input disabled="disabled" type="number" value="0">
+									<td><input disabled="disabled" type="number" value="0" aria-label="Calorie deficit at maintenance in percent">
 									%&nbsp;deficit</td>
 								</tr>										
 								
 								<tr>
-									<td width="33%"><input disabled="disabled" name="kcal_min_form" type="number" value="">
+									<td width="33%"><input disabled="disabled" name="kcal_min_form" type="number" value="" aria-label="Minimum daily calories in kcal">
 									kcal&nbsp;min</td>
 
-									<td width="33%"><input name="target_kcal_form" type="number" value="">
+									<td width="33%"><input name="target_kcal_form" type="number" value="" aria-label="Chosen daily calories in kcal">
 									kcal&nbsp;chosen</td>
 
-									<td><input disabled="disabled" name="kcal_max_form" type="number" value="">
+									<td><input disabled="disabled" name="kcal_max_form" type="number" value="" aria-label="Daily calories at maintenance in kcal">
 									kcal&nbsp;max</td>
 								</tr>
 								
 								<tr>
-									<td><input disabled="disabled" name="fat_min_form" type="number" value="">
+									<td><input disabled="disabled" name="fat_min_form" type="number" value="" aria-label="Minimum fat in grams">
 									g&nbsp;fat&nbsp;min</td>
 
-									<td><input name="target_fat_form" type="number" value="">
+									<td><input name="target_fat_form" type="number" value="" aria-label="Chosen fat in grams">
 									g&nbsp;fat&nbsp;chosen</td>
 
-									<td><input disabled="disabled" name="fat_max_form" type="number" value="">
+									<td><input disabled="disabled" name="fat_max_form" type="number" value="" aria-label="Maximum fat in grams">
 									g&nbsp;fat&nbsp;max</td>
 								</tr>										
 								
@@ -1863,9 +1874,9 @@
                         
 						<p>
 						<ul>
-						<li>Start on <input id="graphstartdate" name="graphstartdate" type="date">.</li>
+						<li><label for="graphstartdate">Start on</label> <input id="graphstartdate" name="graphstartdate" type="date">.</li>
 					
-						<li>Show in <input name="chart_weight_type" type="radio" value="1">lbs or <input name="chart_weight_type" type="radio" value="0">kg</li>
+						<li>Show in <label><input name="chart_weight_type" type="radio" value="1">lbs</label> or <label><input name="chart_weight_type" type="radio" value="0">kg</label></li>
 						</ul></p>
 
 						<div id="chart">
@@ -1874,7 +1885,7 @@
 							</div>
 						</div>
                         
-						<p>For all you data junkies, you can <a id="csvdownload" download="KetoCalculatorForecast.csv" href="javascript:void(0)">download a CSV file of your projected weight loss</a>. This contains all the data used in the above graph.
+						<p>For all you data junkies, you can <a id="csvdownload" download="KetoCalculatorForecast.csv">download a CSV file of your projected weight loss</a>. This contains all the data used in the above graph.
                     </div>
 
 					<!-- Keto Top (7271241487) — second in-content unit. Placed on the
@@ -2058,7 +2069,7 @@
                                 
                         <p>
                             <center>
-                                <textarea class="copytext" cols="2" name="reddit_copypaste" readonly="readonly" rows="13"></textarea>
+                                <textarea class="copytext" cols="2" name="reddit_copypaste" readonly="readonly" rows="13" aria-label="Reddit post text"></textarea>
                             </center>
                         </p>
                         
@@ -2129,7 +2140,7 @@
 				<div id="aboutme">
 					<div id="aboutmewidth">
 						<i class="sprite sprite-me" style="float:left; margin-right: 1em; margin-top:4px;" title="Martin Leitner-Ankerl"></i> Created by <b>Martin Leitner-Ankerl</b>. I'm a software developer who has followed and researched the ketogenic diet for years. I first built this calculator and <a href="https://www.reddit.com/r/keto/comments/127sm0/keto_calculator/" onclick="return gatrack(this);">announced it on /r/keto in October 2012</a>, because the keto advice online was vague and I wanted exact numbers for myself. The math is based on the peer-reviewed Mifflin-St. Jeor equation and the protein and fat guidance in Phinney and Volek's <i>The Art and Science of Low Carbohydrate Living</i> — the book I learned the most from. I'm not a doctor or dietitian; this is simply the tool I wished existed, shared freely. You can find me on <a href="https://www.reddit.com/user/martinus/" onclick="return gatrack(this);">reddit</a> and <a href="https://martin.ankerl.com/" onclick="return gatrack(this);">my blog</a>. Please read the <a href="disclaimer.html" onclick="return gatrack(this);">disclaimer and Cookie Consent</a>.
-						<p style="font-size:smaller; color:#6b7a86; margin-top:0.6em;">Created October 2012 · last reviewed June 2026. The formulas are unchanged since publication and are reviewed periodically for accuracy.</p>
+						<p style="font-size:smaller; color:#98a6b3; margin-top:0.6em;">Created October 2012 · last reviewed June 2026. The formulas are unchanged since publication and are reviewed periodically for accuracy.</p>
 						
 						<span style="clear:left; display:block;"></span>
 					</div>

--- a/index.html
+++ b/index.html
@@ -797,7 +797,7 @@
 		}
 		/* On the dark footer the standard link blue falls below 4.5:1. */
 		#aboutmewidth a {
-			color:#5ab6e0;
+			color:#7fc7e6;
 		}
 
 		a:hover,a:visited:hover
@@ -982,7 +982,7 @@
 			color:#14202b;
 			min-width:62px;
 		}
-		.macro-val i { font-size:14px; font-style:normal; font-weight:500; color:#7a8a96; margin-left:1px; }
+		.macro-val i { font-size:14px; font-style:normal; font-weight:500; color:#5a6b78; margin-left:1px; }
 		.macro-name {
 			font-family:'Space Grotesk','Helvetica Neue',Arial,sans-serif;
 			font-weight:600;
@@ -993,7 +993,7 @@
 		.macro-meta {
 			font-family:'Space Grotesk','Helvetica Neue',Arial,sans-serif;
 			font-size:12.5px;
-			color:#6b7a86;
+			color:#5a6b78;
 			white-space:nowrap;
 		}
 
@@ -1019,7 +1019,7 @@
 			font-family:'PT Serif',Georgia,'Times New Roman',serif;
 			font-size:13px;
 			font-style:italic;
-			color:#6b7a86;
+			color:#5a6b78;
 			margin:14px 0 0;
 			padding-top:13px;
 			border-top:1px solid #dce8f0;
@@ -1053,7 +1053,7 @@
 			color:#14202b;
 			margin:1px 0 4px;
 		}
-		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#566270; }
+		.pie-kcal i { font-style:normal; font-weight:500; font-size:13px; color:#5a6b78; }
 		.pie-col > div[id^="pie_"] { display:inline-block; }
 
 		.recommended {
@@ -1492,8 +1492,7 @@
 	<style>
 	a:focus-visible,
 	button:focus-visible,
-	summary:focus-visible,
-	[tabindex]:focus-visible {
+	summary:focus-visible {
 		outline: 3px solid rgba(18,148,200,0.65);
 		outline-offset: 2px;
 		border-radius: 4px;
@@ -1511,7 +1510,7 @@
 		</div>
         
 		<div id="content">
-			<div id="main" role="main">
+			<main id="main">
                 <div id="broughttoyou">
                     By <a href="https://keto-calculator.ankerl.com/">keto-calculator.ankerl.com</a> &middot; <a href="de/" hreflang="de">Deutsch</a>
                 </div>
@@ -1565,25 +1564,25 @@
 					<p>Given that data, it is possible to calculate your <a href="https://en.wikipedia.org/wiki/Basal_metabolic_rate" onclick="return gatrack(this);">Base Metabolic Rate (BMR)</a>. This site uses the <a href="https://www.freedieting.com/calorie_needs.html" onclick="return gatrack(this);">Mifflin-St.Jeor-Formula</a> which was the most accurate in <a href="https://www.ncbi.nlm.nih.gov/pubmed/15883556" onclick="return gatrack(this);">two</a>&nbsp;<a href="https://www.ncbi.nlm.nih.gov/pubmed/18688113" onclick="return gatrack(this);">studies</a>.</p>
 
 					<ul>
-						<li><input disabled="disabled" name="bmr" type="number" value="" aria-label="Base Metabolic Rate in kcal"> kcal Base Metabolic Rate</li>
+						<li><label><input disabled="disabled" name="bmr" type="number" value=""> kcal Base Metabolic Rate</label></li>
 					</ul>
 					
 					<p>The BMR resembles the resting metabolic rate. The real daily energy expenditure depends on how active you are on average. Based on that activity level we calculate your actual total daily energy expenditure (TDEE). This is the number of calories you need to consume each day when you do not want to lose weight.</p>
 					
 					<ul>
 						<li>
-							<table>
-								<tr><td><input name="level" type="radio" value="0" aria-label="Activity level: sedentary"></td><td>Sedentary. Typical desk job, little to no exercise.</td></tr>
-								<tr><td><input name="level" type="radio" value="1" aria-label="Activity level: lightly active"></td><td>Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</td></tr>
-								<tr><td><input name="level" type="radio" value="2" aria-label="Activity level: moderately active"></td><td>Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</td></tr>
-								<tr><td><input name="level" type="radio" value="3" aria-label="Activity level: very active"></td><td>Very active. Construction workers, hard exercise 6–7 days per week</td></tr>
+							<table role="radiogroup" aria-label="Activity level">
+								<tr><td><input id="level0" name="level" type="radio" value="0"></td><td><label for="level0">Sedentary. Typical desk job, little to no exercise.</label></td></tr>
+								<tr><td><input id="level1" name="level" type="radio" value="1"></td><td><label for="level1">Lightly active. Walking around a good amount, retail jobs. 1–3 hours per week of light exercise.</label></td></tr>
+								<tr><td><input id="level2" name="level" type="radio" value="2"></td><td><label for="level2">Moderately active. 3–5 hours a week, e.g. daily 15 minutes biking and 3 times heavy lifting per week.</label></td></tr>
+								<tr><td><input id="level3" name="level" type="radio" value="3"></td><td><label for="level3">Very active. Construction workers, hard exercise 6–7 days per week</label></td></tr>
 								<tr><td><input name="level" type="radio" value="4" aria-label="Activity level: custom"></td><td>Custom: <input disabled="disabled" name="custom_expenditure" type="number" value="" aria-label="Custom daily energy expenditure in kcal"> kcal</td></tr>
 							</table>
 						</li>
 					</ul>
 
 					<ul>
-						<li><input disabled="disabled" name="energy" type="number" value="" aria-label="Daily energy expenditure in kcal"> kcal daily energy expenditure</li>
+						<li><label><input disabled="disabled" name="energy" type="number" value=""> kcal daily energy expenditure</label></li>
 					</ul>
 
 
@@ -1593,7 +1592,7 @@
 					<p>Let's find out your body fat percentage. Based on your height and weight, your body fat percentage might be <a href="https://www.ncbi.nlm.nih.gov/pubmed/16469982" onclick="return gatrack(this);">around <span class="estimated_bodyfat_percent"></span>%</a>. The most accurate measurement would be a <a href="https://en.wikipedia.org/wiki/Dual_energy_X-ray_absorptiometry" onclick="return gatrack(this);">DEXA</a>. Skin fold measurement with <a href="https://www.amazon.com/gp/product/B0000AN3UB/ref=as_li_ss_tl?ie=UTF8&amp;camp=1789&amp;creative=390957&amp;creativeASIN=B0000AN3UB&amp;linkCode=as2&amp;tag=martanke-20" onclick="return gatrack(this);">a good caliper</a> is also pretty accurate. The easiest way is to just estimate it from some <a href="https://martin.ankerl.com/2016/01/04/body-fat-comparison-pictures/" onclick="return gatrack(this);">comparison pictures</a>. More: <a href="https://www.builtlean.com/2012/09/24/body-fat-percentage-men-women/" onclick="return gatrack(this);">1</a>, <a href="https://www.leighpeele.com/body-fat-pictures-and-percentages" onclick="return gatrack(this);">2</a>, <a href="https://www.nerdfitness.com/blog/2012/07/02/body-fat-percentage/" onclick="return gatrack(this);">3</a>. You can also try <a href="https://www.healthcentral.com/cholesterol/home-body-fat-test-2774-143.html" onclick="return gatrack(this);">this calculator</a> but that can be inaccurate.</p>
 
 					<ul>
-						<li><input name="bodyfat" type="number" value="" placeholder="20" aria-label="Body fat percentage"> % Body fat</li>
+						<li><label><input name="bodyfat" type="number" value="" placeholder="20"> % Body fat</label></li>
 					</ul>
 
 					<p>With <span class="bodyfat_percentage"></span>% body fat you have <span class="lean_lbs"></span>lbs (<span class="lean_kg"></span>kg) of lean body mass, and <span class="fat_lbs"></span>lbs (<span class="fat_kg"></span>kg) of body fat. This includes about <span class="essential_fat_lbs"></span>lbs (<span class="essential_fat_kg"></span>kg) of <a href="https://en.wikipedia.org/wiki/Body_fat_percentage#Typical_body_fat_amounts" onclick="return gatrack(this);">essential body fat</a> that you must not lose.</p>
@@ -1627,7 +1626,7 @@
 
 
 					<ul>
-						<li><input name="carbs" type="number" value="25" aria-label="Daily net carbs in grams"> g daily net carbs (changeable)</li>
+						<li><label><input name="carbs" type="number" value="25"> g daily net carbs (changeable)</label></li>
 					</ul>
 					
 
@@ -2095,7 +2094,7 @@
                         </p>
 					</div>
 				</form>
-			</div>
+			</main>
 
 			
 			

--- a/net-carbs-vs-total-carbs.html
+++ b/net-carbs-vs-total-carbs.html
@@ -148,8 +148,9 @@
 		a{color:#0e6e96;text-decoration:none;transition:color .15s ease;}
 		a:visited{color:#0e6e96;}
 		a:hover,a:visited:hover{color:#0a5675;text-decoration:underline;}
-		/* In-text links must not rely on color alone (WCAG 1.4.1); nav/CTA links keep their own styling. */
-		#main p a,#main li a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
+		/* In-text links must not rely on color alone (WCAG 1.4.1). Masthead/CTA
+		   links keep their own styling; crumbs and footer links are opted in. */
+		#main p a,#main li a,#main td a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
 
 		/* masthead — the cyan brand bar, linked home */
 		#header{
@@ -272,7 +273,7 @@
 		table.examples caption{
 			caption-side:bottom;
 			font-size:13px;
-			color:#5f6e7a;
+			color:#5a6b78;
 			margin-top:8px;
 			text-align:left;
 			font-style:italic;

--- a/net-carbs-vs-total-carbs.html
+++ b/net-carbs-vs-total-carbs.html
@@ -148,6 +148,8 @@
 		a{color:#0e6e96;text-decoration:none;transition:color .15s ease;}
 		a:visited{color:#0e6e96;}
 		a:hover,a:visited:hover{color:#0a5675;text-decoration:underline;}
+		/* In-text links must not rely on color alone (WCAG 1.4.1); nav/CTA links keep their own styling. */
+		#main p a,#main li a,nav.crumbs a,#aboutmewidth a{text-decoration:underline;text-underline-offset:2px;}
 
 		/* masthead — the cyan brand bar, linked home */
 		#header{
@@ -270,7 +272,7 @@
 		table.examples caption{
 			caption-side:bottom;
 			font-size:13px;
-			color:#6b7a86;
+			color:#5f6e7a;
 			margin-top:8px;
 			text-align:left;
 			font-style:italic;


### PR DESCRIPTION
Fixes every failing weighted Lighthouse audit from the PageSpeed report:

**Accessibility (82 → 100):**
- All 30 unlabeled form controls get accessible names — `<label>` wrapping where visible text sits next to the control (sex/chart-unit radios, both date fields), `aria-label` for inputs embedded mid-sentence (weights, heights, macro min/chosen/max fields, activity radios, computed outputs). Every new label is translated on the German page via `build_de.py`.
- Positive `tabindex` (1–6) removed — DOM order is already the correct tab order.
- In-text links underlined (WCAG 1.4.1) on calculator + guide pages; header/nav/CTA links keep their styling.
- Contrast fixes: pie kcal units, footer link + fine-print on the dark footer, guide table captions.
- `role="main"` landmark.

**SEO (92 → 100):** CSV download link drops `href="javascript:void(0)"` — `update_csv()` has always assigned the real data URI.

**Verified:** local Lighthouse 100/100 on the calculator, 100 accessibility on guides; calculator behavior unchanged in headless Chromium (computations, label-click radio toggling, legacy date migration, localStorage restore, share links, zero console errors); all generators clean (CI verify job enforces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GouHHXYtinKnRvD2nGCwqK

---
_Generated by [Claude Code](https://claude.ai/code/session_01GouHHXYtinKnRvD2nGCwqK)_